### PR TITLE
[ci] Add simple build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,8 @@
 name: build validation
 
 on:
-  pull_request:
   workflow_dispatch:
+  pull_request:
   push:
     branches: [ $default-branch ]
 
@@ -18,3 +18,30 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '8.x'
+
+      - name: Install MAUI
+        run: dotnet workload install maui
+
+      - name: Install objectivesharpie
+        run: brew install objectivesharpie
+
+      - name: Create logs dir
+        run: mkdir -p ${{ runner.temp }}/logs/
+
+      - name: Build facebook
+        working-directory: ./facebook
+        run: dotnet build -v:n -bl:${{ runner.temp }}/logs/facebook.binlog
+
+      - name: Build firebase
+        working-directory: ./firebase/macios
+        run: dotnet build -v:n -bl:${{ runner.temp }}/logs/firebase-macios.binlog
+
+      - name: Build googlecast
+        working-directory: ./googlecast/macios
+        run: dotnet build -v:n -bl:${{ runner.temp }}/logs/googlecast-macios.binlog
+
+      - name: Upload logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-logs
+          path: ${{ runner.temp }}/logs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: microsoft
+          java-version: 17
+
       - name: Use .NET 8.x
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: build validation
+name: validation
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: build
     runs-on: macos-14
     steps:
       - name: Checkout
@@ -39,15 +39,7 @@ jobs:
 
       - name: Build facebook
         working-directory: ./facebook
-        run: dotnet build -v:n -bl:${{ runner.temp }}/logs/facebook.binlog
-
-      - name: Build firebase
-        working-directory: ./firebase/macios
-        run: dotnet build -v:n -bl:${{ runner.temp }}/logs/firebase-macios.binlog
-
-      - name: Build googlecast
-        working-directory: ./googlecast/macios
-        run: dotnet build -v:n -bl:${{ runner.temp }}/logs/googlecast-macios.binlog
+        run: dotnet build -bl:${{ runner.temp }}/logs/facebook.binlog
 
       - name: Upload logs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
 
       - name: Upload logs
         uses: actions/upload-artifact@v4
+        if: always()
         with:
           name: build-logs
           path: ${{ runner.temp }}/logs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,15 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+
+      - name: Use .NET 8.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'
 
       - name: Install JDK 17
         uses: actions/setup-java@v4
@@ -20,10 +25,8 @@ jobs:
           distribution: microsoft
           java-version: 17
 
-      - name: Use .NET 8.x
-        uses: actions/setup-dotnet@v4
-        with:
-          dotnet-version: '8.x'
+      - name: Use Xcode 15.3
+        run: sudo xcode-select -s /Applications/Xcode_15.3.app/Contents/Developer
 
       - name: Install MAUI
         run: dotnet workload install maui

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,20 @@
+name: build validation
+
+on:
+  pull_request:
+  workflow_dispatch:
+  push:
+    branches: [ $default-branch ]
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Use .NET 8.x
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.x'

--- a/eng/Common.android.targets
+++ b/eng/Common.android.targets
@@ -1,28 +1,28 @@
 <Project>
 
+	<PropertyGroup>
+		<_AndroidProjectDirFullPath>$([System.IO.Path]::GetFullPath($(AndroidProjectDir)))</_AndroidProjectDirFullPath>
+
+		<_AndroidProjectModuleBuildPath>$(_AndroidProjectDirFullPath)/$(AndroidProjectModule)/build</_AndroidProjectModuleBuildPath>
+		<_AndroidAarOutputPath>$(_AndroidProjectModuleBuildPath)/outputs/aar/$(AndroidProjectModule).aar</_AndroidAarOutputPath>
+		<AndroidBuildAar Condition=" '$(AndroidBuildAar)' == '' ">True</AndroidBuildAar>
+
+		<_AndroidGradleW>gradlew</_AndroidGradleW>
+		<_AndroidGradleW Condition="$([MSBuild]::IsOSPlatform('windows'))">$(_AndroidGradleW).exe</_AndroidGradleW>
+		<_AndroidGradleWFullPath>$([System.IO.Path]::Combine($(_AndroidProjectDirFullPath), $(_AndroidGradleW)))</_AndroidGradleWFullPath>
+
+		<_AndroidHome>$([System.Environment]::GetEnvironmentVariable('ANDROID_HOME'))</_AndroidHome>
+		<_AndroidHome Condition=" '$(_AndroidHome)' == '' ">$(HOME)/Library/Developer/Xamarin/android-sdk-macosx</_AndroidHome>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.java" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
+		<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.gradle" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
+		<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.xml" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
+		<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.properties" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
+	</ItemGroup>
+
 	<Target Condition=" '$(AndroidBuildAar)' == 'true' " DependsOnTargets="$(BuildAarDependsOnTargets)" BeforeTargets="ProcessFrameworkReferences" Name="BuildAar" Inputs="@(_AndroidGradleInputs)" Outputs="$(_AndroidAarOutputPath)">
-
-		<PropertyGroup>
-			<_AndroidProjectDirFullPath>$([System.IO.Path]::GetFullPath($(AndroidProjectDir)))</_AndroidProjectDirFullPath>
-
-			<_AndroidProjectModuleBuildPath>$(_AndroidProjectDirFullPath)/$(AndroidProjectModule)/build</_AndroidProjectModuleBuildPath>
-			<_AndroidAarOutputPath>$(_AndroidProjectModuleBuildPath)/outputs/aar/$(AndroidProjectModule).aar</_AndroidAarOutputPath>
-			<AndroidBuildAar Condition=" '$(AndroidBuildAar)' == '' ">True</AndroidBuildAar>
-		
-			<_AndroidGradleW>gradlew</_AndroidGradleW>
-			<_AndroidGradleW Condition="$([MSBuild]::IsOSPlatform('windows'))">$(_AndroidGradleW).exe</_AndroidGradleW>
-			<_AndroidGradleWFullPath>$([System.IO.Path]::Combine($(_AndroidProjectDirFullPath), $(_AndroidGradleW)))</_AndroidGradleWFullPath>
-
-			<_AndroidHome>$([System.Environment]::GetEnvironmentVariable('ANDROID_HOME'))</_AndroidHome>
-			<_AndroidHome Condition=" '$(_AndroidHome)' == '' ">$(HOME)/Library/Developer/Xamarin/android-sdk-macosx</_AndroidHome>
-		</PropertyGroup>
-
-		<ItemGroup>
-			<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.java" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
-			<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.gradle" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
-			<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.xml" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
-			<_AndroidGradleInputs Include="$(_AndroidProjectDirFullPath)/**/*.properties" Exclude="$(_AndroidProjectModuleBuildPath)/**/*" />
-		</ItemGroup>
 
 		<Error Condition=" '$(AndroidProjectDir)' == '' " Text="The AndroidProjectDir property must be set." />
 		<Error Condition=" '$(AndroidProjectModule)' == '' " Text="The AndroidProjectModule property must be set." />


### PR DESCRIPTION
Adds a primitive build workflow to help validate incoming changes and
ensure that the repo continues to build successfully.

Currently only the facebook binding is being built.

The facebook android build has been fixed by moving the props/items
that the aar build target depends on outside the target.