### PR TITLE
Add Microsoft.Maui.BindingExtensions.Build.Tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Create logs dir
         run: mkdir -p ${{ runner.temp }}/logs/
 
+      - name: Build and test build tasks
+        working-directory: ./eng
+        run: >-
+          dotnet test Microsoft.Maui.BindingExtensions.Build.Tasks.sln
+          --logger trx --results-directory ${{ runner.temp }}/logs/TestResults-build-tasks
+          -bl:${{ runner.temp }}/logs/build-tasks.binlog
+
       - name: Build facebook
         working-directory: ./facebook
         run: dotnet build -m:1 -bl:${{ runner.temp }}/logs/facebook.binlog

--- a/eng/Directory.Build.props
+++ b/eng/Directory.Build.props
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project>
+
+  <PropertyGroup>
+    <LangVersion>latest</LangVersion>
+    <MSBuildPackageReferenceVersion>17.9.5</MSBuildPackageReferenceVersion>
+  </PropertyGroup>
+
+</Project>

--- a/eng/Microsoft.Maui.BindingExtensions.Build.Tasks.sln
+++ b/eng/Microsoft.Maui.BindingExtensions.Build.Tasks.sln
@@ -1,0 +1,31 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.11.34809.278
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.BindingExtensions.Build.Tasks", "src\Microsoft.Maui.BindingExtensions.Build.Tasks\Microsoft.Maui.BindingExtensions.Build.Tasks.csproj", "{D1497B0B-A62D-49AD-833B-EFE4F87B1BEE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.Maui.BindingExtensions.Build.Tests", "test\Microsoft.Maui.BindingExtensions.Build.Tests\Microsoft.Maui.BindingExtensions.Build.Tests.csproj", "{7BF30708-BC47-4379-8DC0-E7093AC2FED6}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{D1497B0B-A62D-49AD-833B-EFE4F87B1BEE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{D1497B0B-A62D-49AD-833B-EFE4F87B1BEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{D1497B0B-A62D-49AD-833B-EFE4F87B1BEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{D1497B0B-A62D-49AD-833B-EFE4F87B1BEE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7BF30708-BC47-4379-8DC0-E7093AC2FED6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7BF30708-BC47-4379-8DC0-E7093AC2FED6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7BF30708-BC47-4379-8DC0-E7093AC2FED6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7BF30708-BC47-4379-8DC0-E7093AC2FED6}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4D467CE9-10CC-4EBD-B51D-B4B3643492AE}
+	EndGlobalSection
+EndGlobal

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/MSBuildExtensions.cs
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/MSBuildExtensions.cs
@@ -1,0 +1,22 @@
+﻿using Microsoft.Build.Utilities;
+
+namespace Microsoft.Maui.BindingExtensions.Build.Tasks
+{
+    public static class MSBuildExtensions
+    {
+        public static void LogCodedError(this TaskLoggingHelper log, string code, string message, params object[] messageArgs)
+        {
+            log.LogError(
+                subcategory: string.Empty,
+                errorCode: code,
+                helpKeyword: string.Empty,
+                file: string.Empty,
+                lineNumber: 0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: message,
+                messageArgs: messageArgs);
+        }
+    }
+}

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Microsoft.Maui.BindingExtensions.Build.Tasks.csproj
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Microsoft.Maui.BindingExtensions.Build.Tasks.csproj
@@ -1,0 +1,14 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageReferenceVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/BindingToolTask.cs
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/BindingToolTask.cs
@@ -1,0 +1,50 @@
+﻿using System.Text;
+using Microsoft.Build.Framework;
+using Microsoft.Build.Utilities;
+
+namespace Microsoft.Maui.BindingExtensions.Build.Tasks
+{
+    public abstract class BindingToolTask : ToolTask
+    {
+        public abstract string TaskPrefix { get; }
+
+        protected string WorkingDirectory { get; private set; }
+
+        StringBuilder toolOutput = new StringBuilder();
+
+        public BindingToolTask()
+        {
+            WorkingDirectory = Directory.GetCurrentDirectory();
+        }
+
+        public override bool Execute()
+        {
+            try
+            {
+                bool taskResult = RunTask();
+                if (!taskResult && !string.IsNullOrEmpty(toolOutput.ToString()))
+                {
+                    Log.LogCodedError($"{TaskPrefix}0000", toolOutput.ToString().Trim());
+
+                }
+                toolOutput.Clear();
+                return taskResult;
+            }
+            catch (Exception ex)
+            {
+                Log.LogCodedError($"{TaskPrefix}0001", ex.ToString());
+                return false;
+            }
+        }
+
+        protected override void LogEventsFromTextOutput(string singleLine, MessageImportance messageImportance)
+        {
+            base.LogEventsFromTextOutput(singleLine, messageImportance);
+            toolOutput.AppendLine(singleLine);
+        }
+
+        public virtual bool RunTask() => base.Execute();
+
+        protected object ProjectSpecificTaskObjectKey(object key) => (key, WorkingDirectory);
+    }
+}

--- a/eng/test/Microsoft.Maui.BindingExtensions.Build.Tests/BindingToolTaskTests.cs
+++ b/eng/test/Microsoft.Maui.BindingExtensions.Build.Tests/BindingToolTaskTests.cs
@@ -1,0 +1,53 @@
+﻿using FluentAssertions;
+using Microsoft.Maui.BindingExtensions.Build.Tasks;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.BindingExtensions.Build.Tests
+{
+    [TestFixture]
+    public class BindingToolTaskTests
+    {
+        MockBuildEngine engine = new MockBuildEngine();
+
+        public class DotnetToolOutputTestTask : BindingToolTask
+        {
+            public override string TaskPrefix { get; } = "DTOT";
+            protected override string ToolName => "dotnet";
+            protected override string GenerateFullPathToTool() => ToolExe;
+            public string CommandLineArgs { get; set; } = "--info";
+            protected override string GenerateCommandLineCommands() => CommandLineArgs;
+        }
+
+        [SetUp]
+        public void Setup()
+        {
+            engine.ClearEvents();
+        }
+
+        [Test]
+        [TestCase("invalidcommand", false, "You intended to execute a .NET program, but dotnet-invalidcommand does not exist.")]
+        [TestCase("--info", true, "")]
+        public void ShouldRunAndLogOnError(string args, bool expectedResult, string expectedErrorText)
+        {
+            var task = new DotnetToolOutputTestTask()
+            {
+                BuildEngine = engine,
+                CommandLineArgs = args,
+            };
+            var taskSucceeded = task.Execute();
+            taskSucceeded.Should().Be(expectedResult, "Task execution did not return expected value.");
+           
+            if (taskSucceeded)
+            {
+                engine.Errors.Should().BeEmpty("Successful task should not have any errors.");
+            }
+            else
+            {
+                engine.Errors.Should().NotBeEmpty("Task expected to fail should have errors.");
+                engine.Errors[0].Code.Should().Be("MSB6006");
+                engine.Errors[1].Code.Should().Be("DTOT0000");
+                engine.Errors[1].Message.Should().Contain(expectedErrorText);
+            }
+        }
+    }
+}

--- a/eng/test/Microsoft.Maui.BindingExtensions.Build.Tests/Microsoft.Maui.BindingExtensions.Build.Tests.csproj
+++ b/eng/test/Microsoft.Maui.BindingExtensions.Build.Tests/Microsoft.Maui.BindingExtensions.Build.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <RollForward>major</RollForward>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="FluentAssertions" Version="6.12.0" />
+    <PackageReference Include="Microsoft.Build.Framework" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.Build.Tasks.Core" Version="$(MSBuildPackageReferenceVersion)" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="NUnit" Version="4.1.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Microsoft.Maui.BindingExtensions.Build.Tasks\Microsoft.Maui.BindingExtensions.Build.Tasks.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/eng/test/Microsoft.Maui.BindingExtensions.Build.Tests/MockBuildEngine.cs
+++ b/eng/test/Microsoft.Maui.BindingExtensions.Build.Tests/MockBuildEngine.cs
@@ -1,0 +1,96 @@
+﻿using System.Collections;
+using Microsoft.Build.Framework;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.BindingExtensions.Build.Tests
+{
+    public class MockBuildEngine : IBuildEngine4
+    {
+        public int ColumnNumberOfTaskNode { get; set; }
+
+        public bool ContinueOnError { get; set; }
+
+        public int LineNumberOfTaskNode { get; set; }
+
+        public string ProjectFileOfTaskNode => "test.xml";
+
+        public IList<CustomBuildEventArgs> CustomEvents { get; set; } = new List<CustomBuildEventArgs>();
+
+        public IList<BuildErrorEventArgs> Errors { get; set; } = new List<BuildErrorEventArgs>();
+
+        public IList<BuildMessageEventArgs> Messages { get; set; } = new List<BuildMessageEventArgs>();
+
+        public IList<BuildWarningEventArgs> Warnings { get; set; } = new List<BuildWarningEventArgs>();
+
+        Dictionary<object, object> RegisteredTaskObjects { get; } = new Dictionary<object, object>();
+
+        int RegisteredTaskObjectsQueries = 0;
+
+        public bool IsRunningMultipleNodes => false;
+
+        public TextWriter Output { get; set; } = TestContext.Out;
+
+        public void ClearEvents()
+        {
+            CustomEvents.Clear();
+            Errors.Clear();
+            Messages.Clear();
+            Warnings.Clear();
+        }
+
+        public void LogCustomEvent(CustomBuildEventArgs e)
+        {
+            Output.WriteLine($"Custom: {e.Message}");
+            CustomEvents.Add(e);
+        }
+
+        public void LogErrorEvent(BuildErrorEventArgs e)
+        {
+            Output.WriteLine($"Error: {e.Message}");
+            Errors.Add(e);
+        }
+
+        public void LogMessageEvent(BuildMessageEventArgs e)
+        {
+            Output.WriteLine($"Message: {e.Message}");
+            Messages.Add(e);
+        }
+
+        public void LogWarningEvent(BuildWarningEventArgs e)
+        {
+            Output.WriteLine($"Warning: {e.Message}");
+            Warnings.Add(e);
+        }
+
+        public virtual object? GetRegisteredTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            RegisteredTaskObjectsQueries++;
+            RegisteredTaskObjects.TryGetValue(key, out object? ret);
+            return ret;
+        }
+
+        public void RegisterTaskObject(object key, object obj, RegisteredTaskObjectLifetime lifetime, bool allowEarlyCollection)
+        {
+            RegisteredTaskObjects.Add(key, obj);
+        }
+
+        public object UnregisterTaskObject(object key, RegisteredTaskObjectLifetime lifetime)
+        {
+            var obj = RegisteredTaskObjects[key];
+            RegisteredTaskObjects.Remove(key);
+            return obj;
+        }
+
+        public void Yield() { }
+
+        public void Reacquire() { }
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs) => true;
+
+        public bool BuildProjectFile(string projectFileName, string[] targetNames, IDictionary globalProperties, IDictionary targetOutputs, string toolsVersion) => true;
+        
+        public BuildEngineResult BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IList<string>[] removeGlobalProperties, string[] toolsVersion, bool returnTargetOutputs) => new();
+
+        public bool BuildProjectFilesInParallel(string[] projectFileNames, string[] targetNames, IDictionary[] globalProperties, IDictionary[] targetOutputsPerProject, string[] toolsVersion, bool useResultsCache, bool unloadProjectsOnCompletion) => true;
+    }
+}


### PR DESCRIPTION
Adds mostly empty build task and test scaffolding.  Logic from the
Common.android.targets and Common.macios.targets will be migrated into
this new MSBuild project.