### PR TITLE
[macios] Add `@(XcodeProjectReference)`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -403,6 +403,7 @@ FodyWeavers.xsd
 
 xcuserdata/
 
+build/
 .build/
 *.xcframework
 Pods/

--- a/eng/Common.macios.targets
+++ b/eng/Common.macios.targets
@@ -1,94 +1,118 @@
 <Project>
 
-	<PropertyGroup>
-		<Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+  <Import Project="$(MSBuildThisFileDirectory)Common.targets" Condition=" '$(CommonTargetsImported)' != 'true' " />
 
-		<XcodeDefaultBuildDir>.build</XcodeDefaultBuildDir>
-		<XcodeBuildDirName Condition=" '$(XcodeBuildDirName)' == '' ">$(XcodeDefaultBuildDir)</XcodeBuildDirName>
+  <UsingTask TaskName="Sharpie" AssemblyFile="$(BindingExtBuildTasksAssembly)"/>
+  <UsingTask TaskName="XcodeBuild" AssemblyFile="$(BindingExtBuildTasksAssembly)"/>
 
-		<_XcodeProjectFullPath>$([System.IO.Path]::GetFullPath($(XcodeProject)))</_XcodeProjectFullPath>
+  <PropertyGroup>
+    <XcodeProjectConfiguration Condition=" '$(XcodeProjectConfiguration)' == '' ">Release</XcodeProjectConfiguration>
+    <XcodeBuildiOS Condition=" '$(XcodeBuildiOS)' == '' ">true</XcodeBuildiOS>
+    <XcodeBuildiOSSimulator Condition=" '$(XcodeBuildiOSSimulator)' == '' ">true</XcodeBuildiOSSimulator>
+    <XcodeBuildMacCatalyst Condition=" '$(XcodeBuildMacCatalyst)' == '' ">true</XcodeBuildMacCatalyst>
+    <EnableDefaultSharpieiOSItems Condition=" '$(EnableDefaultSharpieiOSItems)' == '' ">false</EnableDefaultSharpieiOSItems>
 
-		<XcodeScheme Condition=" '$(XcodeScheme)' == '' ">$([System.IO.Path]::GetFilenameWithoutExtension($(XcodeProject)))</XcodeScheme>
+    <_XcArchiveExtraArgs>$(_XcArchiveExtraArgs) ENABLE_BITCODE=NO SKIP_INSTALL=NO SWIFT_INSTALL_OBJC_HEADER=YES BUILD_LIBRARY_FOR_DISTRIBUTION=YES</_XcArchiveExtraArgs>
+    <_XcArchiveExtraArgs>$(_XcArchiveExtraArgs) OTHER_LDFLAGS=&quot;-ObjC&quot; OTHER_SWIFT_FLAGS=&quot;-no-verify-emitted-module-interface&quot; OBJC_CFLAGS=&quot;-fno-objc-msgsend-selector-stubs -ObjC&quot;</_XcArchiveExtraArgs>
+  </PropertyGroup>
 
-		<XcodeProjectDir Condition=" '$(XcodeProjectDir)' == '' ">$([System.IO.Path]::GetDirectoryName($(_XcodeProjectFullPath)))</XcodeProjectDir>
-		<XcodeBuildDir Condition=" '$(XcodeBuildDir)' == '' ">$([System.IO.Path]::Combine($(XcodeProjectDir), $(XcodeBuildDirName)))</XcodeBuildDir>
+  <PropertyGroup Condition="$(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst'))">
+    <_GenerateBindingsDependsOn>
+      _BuildXcodeProjects;
+      _SharpieBindXcodeProjects;
+      $(_GenerateBindingsDependsOn);
+    </_GenerateBindingsDependsOn>
+  </PropertyGroup>
 
-		<XcodeBuildXCFramework Condition=" '$(XcodeBuildXCFramework)' == '' ">True</XcodeBuildXCFramework>
-		
-		<XcodeBuildiOS Condition=" '$(XcodeBuildiOS)' == '' ">True</XcodeBuildiOS>
-		<XcodeBuildiOSSimulator Condition=" '$(XcodeBuildiOSSimulator)' == '' ">True</XcodeBuildiOSSimulator>
-		<XcodeBuildMacCatalyst Condition=" '$(XcodeBuildMacCatalyst)' == '' ">True</XcodeBuildMacCatalyst>
+  <ItemDefinitionGroup>
+    <XcodeProjectReference>
+      <Kind>Framework</Kind>
+      <SmartLink>true</SmartLink>
+    </XcodeProjectReference>
+  </ItemDefinitionGroup>
 
-		<_XcodeBuildDirFullPath>$([System.IO.Path]::GetFullPath($(XcodeBuildDir)))</_XcodeBuildDirFullPath>
-		<_XcodeProjectDirFullPath>$([System.IO.Path]::GetFullPath($(XcodeProjectDir)))</_XcodeProjectDirFullPath>
+  <!-- TODO Fix incremental builds -->
+  <Target Name="_GetBuildXcodeProjectsInputs">
+    <ItemGroup>
+      <_XcbInputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)**/*.swift')" />
+      <_XcbInputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)**/*.h')" />
+      <_XcbInputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)**/*.pbxproj')" />
+      <_XcbInputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)**/*.xcworkspace')"/>
+      <_XcbInputs Remove="@(XcodeProjectReference->'%(RootDir)%(Directory)build/**/*')" />
+    </ItemGroup>
+  </Target>
 
-		<_XcArchiveiOSFullPath>$([System.IO.Path]::Combine($(_XcodeBuildDirFullPath), $(XcodeScheme)-ios.xcarchive))</_XcArchiveiOSFullPath>
-		<_XcArchiveiOSSimulatorFullPath>$([System.IO.Path]::Combine($(_XcodeBuildDirFullPath), $(XcodeScheme)-iossimulator.xcarchive))</_XcArchiveiOSSimulatorFullPath>
-		<_XcArchiveMacCatalystFullPath>$([System.IO.Path]::Combine($(_XcodeBuildDirFullPath), $(XcodeScheme)-maccatalyst.xcarchive))</_XcArchiveMacCatalystFullPath>
-		<_XcArchiveExtraArgs>ENABLE_BITCODE=NO SKIP_INSTALL=NO SWIFT_INSTALL_OBJC_HEADER=YES BUILD_LIBRARY_FOR_DISTRIBUTION=YES OTHER_LDFLAGS='-ObjC' OTHER_SWIFT_FLAGS='-no-verify-emitted-module-interface' OBJC_CFLAGS='-fno-objc-msgsend-selector-stubs -ObjC'</_XcArchiveExtraArgs>
+  <Target Name="_BuildXcodeProjects"
+      Condition=" '@(XcodeProjectReference->Count())' != '0' "
+      DependsOnTargets="_EnsureBuildTasksAssembly;_GetBuildXcodeProjectsInputs;$(BuildXcodeProjectsDependsOnTargets)"
+      Inputs="@(_XcbInputs)"
+      Outputs="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(SchemeName).xcframework/Info.plist')" >
 
-		<_XcFrameworkFullPath>$([System.IO.Path]::Combine($(_XcodeBuildDirFullPath), $(XcodeScheme).xcframework))</_XcFrameworkFullPath>
-	</PropertyGroup>
+    <!-- Create xcarchive files for configured platforms -->
+    <XcodeBuild Condition=" '$(XcodeBuildiOS)' == 'true' "
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(SchemeName)-ios.xcarchive')&quot; -destination &quot;generic/platform=iOS&quot; $(_XcArchiveExtraArgs)"
+        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
+    </XcodeBuild>
 
-	<ItemGroup>
-		<_XcodeProjectInputs Include="$(_XcodeProjectDirFullPath)/**/*.swift" Exclude="$(_XcodeBuildDirFullPath)/**" />
-		<_XcodeProjectInputs Include="$(_XcodeProjectDirFullPath)/**/*.h" Exclude="$(_XcodeBuildDirFullPath)/**" />
-		<_XcodeProjectInputs Include="$(_XcodeProjectFullPath)/*.pbxproj" />
-		<_XcodeProjectInputs Include="$(_XcodeProjectFullPath)/*.xcworkspace" />
-	</ItemGroup>
+    <XcodeBuild Condition=" '$(XcodeBuildiOSSimulator)' == 'true' "
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(SchemeName)-iossimulator.xcarchive')&quot; -destination &quot;generic/platform=iOS Simulator&quot; $(_XcArchiveExtraArgs)"
+        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
+    </XcodeBuild>
 
-	<PropertyGroup Condition="$(TargetFramework.Contains('ios')) Or $(TargetFramework.Contains('maccatalyst'))">
-		<_GenerateBindingsDependsOn>
-			BuildXCFramework;
-			ObjSharpieBind;
-			$(_GenerateBindingsDependsOn);
-		</_GenerateBindingsDependsOn>
-	</PropertyGroup>
+    <XcodeBuild Condition=" '$(XcodeBuildMacCatalyst)' == 'true' "
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(SchemeName)-maccatalyst.xcarchive')&quot; -destination &quot;generic/platform=macOS,variant=Mac Catalyst&quot; $(_XcArchiveExtraArgs)"
+        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
+    </XcodeBuild>
 
-	<Target Name="BuildXCFramework"
-			Condition=" '$(XcodeBuildXCFramework)' == 'true' "
-			DependsOnTargets="$(BuildXCFrameworkDependsOnTargets)"
-			Inputs="@(_XcodeProjectInputs)"
-			Outputs="$(_XcFrameworkFullPath)/Info.plist">
-		<Error Condition=" !Exists('$(_XcodeProjectFullPath)') " Text="Xcode project '$(_XcodeProjectFullPath)' not found." />
+    <!-- Create xcframework file from xcarchive files -->
+    <ItemGroup>
+      <_CreateXcFxArgs Include="-create-xcframework" />
+      <_CreateXcFxArgs Condition=" '$(XcodeBuildiOS)' == 'true' "           Include="@(XcodeProjectReference->'-archive %(RootDir)%(Directory)build/%(SchemeName)-ios.xcarchive')" />
+      <_CreateXcFxArgs Condition=" '$(XcodeBuildiOS)' == 'true' "           Include="-framework %(XcodeProjectReference.SchemeName).framework" />
+      <_CreateXcFxArgs Condition=" '$(XcodeBuildiOSSimulator)' == 'true' "  Include="@(XcodeProjectReference->'-archive %(RootDir)%(Directory)build/%(SchemeName)-iossimulator.xcarchive')" />
+      <_CreateXcFxArgs Condition=" '$(XcodeBuildiOSSimulator)' == 'true' "  Include="-framework %(XcodeProjectReference.SchemeName).framework" />
+      <_CreateXcFxArgs Condition=" '$(XcodeBuildMacCatalyst)' == 'true' "   Include="@(XcodeProjectReference->'-archive %(RootDir)%(Directory)build/%(SchemeName)-maccatalyst.xcarchive')" />
+      <_CreateXcFxArgs Condition=" '$(XcodeBuildMacCatalyst)' == 'true' "   Include="-framework %(XcodeProjectReference.SchemeName).framework" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)build/%(SchemeName).xcframework')" />
+    </ItemGroup>
 
-		<Exec Condition=" '$(XcodeBuildiOS)' == 'True' "			Command="xcodebuild -project $(_XcodeProjectFullPath) archive -scheme $(XcodeScheme) -configuration $(Configuration) -archivePath $(_XcArchiveiOSFullPath) -destination 'generic/platform=iOS' $(_XcArchiveExtraArgs)" />
-		<Exec Condition=" '$(XcodeBuildiOSSimulator)' == 'True' "	Command="xcodebuild -project $(_XcodeProjectFullPath) archive -scheme $(XcodeScheme) -configuration $(Configuration) -archivePath $(_XcArchiveiOSSimulatorFullPath) -destination 'generic/platform=iOS Simulator' $(_XcArchiveExtraArgs)" />
-		<Exec Condition=" '$(XcodeBuildMacCatalyst)' == 'True' "	Command="xcodebuild -project $(_XcodeProjectFullPath) archive -scheme $(XcodeScheme) -configuration $(Configuration) -archivePath $(_XcArchiveMacCatalystFullPath) -destination 'generic/platform=macOS,variant=Mac Catalyst' $(_XcArchiveExtraArgs)" />
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(SchemeName).xcframework')" />
 
-		<ItemGroup>
-			<_CreateXcFxArgs Include="-create-xcframework" />
-			<_CreateXcFxArgs Condition=" '$(XcodeBuildiOS)' == 'True' "				Include="-archive $(_XcArchiveiOSFullPath) -framework $(XcodeScheme).framework" />
-			<_CreateXcFxArgs Condition=" '$(XcodeBuildiOSSimulator)' == 'True' "	Include="-archive $(_XcArchiveiOSSimulatorFullPath) -framework $(XcodeScheme).framework" />
-			<_CreateXcFxArgs Condition=" '$(XcodeBuildMacCatalyst)' == 'True' "		Include="-archive $(_XcArchiveMacCatalystFullPath) -framework $(XcodeScheme).framework" />
-			<_CreateXcFxArgs Include="-output $(_XcFrameworkFullPath)" />
-		</ItemGroup>
+    <XcodeBuild Arguments="@(_CreateXcFxArgs, ' ')"
+        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
+    </XcodeBuild>
 
-		<RemoveDir Directories="$(_XcFrameworkFullPath)" />
-		<Exec Command="xcodebuild @(_CreateXcFxArgs, ' ')" />
-	</Target>
+    <ItemGroup>
+      <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(SchemeName).xcframework')">
+        <Kind>%(XcodeProjectReference.Kind)</Kind>
+        <SmartLink>%(XcodeProjectReference.SmartLink)</SmartLink>
+      </NativeReference>
+    </ItemGroup>
 
-	<PropertyGroup>
-		<ObjSharpieBind Condition=" '$(ObjSharpieBind)' == '' ">True</ObjSharpieBind>
-		<ObjSharpieBindOutputDir Condition=" '$(ObjSharpieBindOutputDir)' == '' ">$(_XcodeBuildDirFullPath)/Binding</ObjSharpieBindOutputDir>
-		<ObjSharpieSourceHeader>$(_XcArchiveiOSFullPath)/Products/Library/Frameworks/$(XcodeScheme).framework/Headers/$(XcodeScheme)-Swift.h</ObjSharpieSourceHeader>
-	</PropertyGroup>
+    <Error Condition=" !Exists('@(NativeReference)') " Text="Xcode project built successfully but did not produce expected output file: '@(NativeReference)'" />
+    <Message Text="Adding reference to Xcode project output: @(NativeReference)" />
+  </Target>
 
-	<ItemGroup>
-		<ObjcBindingApiDefinitionFiles Include="$(ObjSharpieBindOutputDir)/ApiDefinitions.cs" />
-		<_ObjSharpieInputs Include="$(ObjSharpieSourceHeader)" />
-	</ItemGroup>
 
-	<Target Name="ObjSharpieBind"
-			Condition="'$(ObjSharpieBind)' == 'true'"
-			Inputs="@(_ObjSharpieInputs)"
-			Outputs="@(ObjcBindingApiDefinitionFiles)">
-		<ItemGroup>
-			<_ObjSharpieArgs Include="--output=$(ObjSharpieBindOutputDir)" />
-			<_ObjSharpieArgs Include="--namespace=$(ObjSharpieBindNamespace)" />
-			<_ObjSharpieArgs Include="--framework $(_XcArchiveiOSFullPath)/Products/Library/Frameworks/$(XcodeScheme).framework" />
-		</ItemGroup>
-		<Exec Command="sharpie bind @(_ObjSharpieArgs, ' ')" />
-	</Target>
+  <Target Name="_GetSharpieBindInputs">
+    <ItemGroup>
+      <_SharpieInputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(SchemeName)-ios.xcarchive/Products/Library/Frameworks/%(SchemeName).framework')" />
+    </ItemGroup>
+  </Target>
+
+  <Target Name="_SharpieBindXcodeProjects"
+      Condition=" '@(XcodeProjectReference->Count())' != '0' and '@(XcodeProjectReference->'%(SharpieBind)')' == 'true' "
+      DependsOnTargets="_GetSharpieBindInputs"
+      Inputs="@(_SharpieInputs)"
+      Outputs="@(XcodeProjectReference->'%(RootDir)%(Directory)build/sharpie/ApiDefinitions.cs')">
+
+    <ItemGroup>
+      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--output=%(RootDir)%(Directory)build/sharpie')" />
+      <_ObjSharpieArgs Include="--namespace=%(XcodeProjectReference.SharpieNamespace)" />
+      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--framework %(RootDir)%(Directory)build/%(SchemeName)-ios.xcarchive/Products/Library/Frameworks/%(SchemeName).framework')" />
+    </ItemGroup>
+
+    <Sharpie Arguments="bind @(_ObjSharpieArgs, ' ')" />
+  </Target>
 
 </Project>

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/MSBuildExtensions.cs
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/MSBuildExtensions.cs
@@ -18,5 +18,21 @@ namespace Microsoft.Maui.BindingExtensions.Build.Tasks
                 message: message,
                 messageArgs: messageArgs);
         }
+
+        public static void LogCodedWarning(this TaskLoggingHelper log, string code, string message, params object [] messageArgs)
+        {
+            log.LogWarning(
+                subcategory: string.Empty,
+                warningCode: code,
+                helpKeyword: string.Empty,
+                file: string.Empty,
+                lineNumber: 0,
+                columnNumber: 0,
+                endLineNumber: 0,
+                endColumnNumber: 0,
+                message: message,
+                messageArgs: messageArgs);
+        }
+
     }
 }

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/BindingToolTask.cs
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/BindingToolTask.cs
@@ -1,4 +1,5 @@
 ﻿using System.Text;
+
 using Microsoft.Build.Framework;
 using Microsoft.Build.Utilities;
 
@@ -31,7 +32,7 @@ namespace Microsoft.Maui.BindingExtensions.Build.Tasks
             }
             catch (Exception ex)
             {
-                Log.LogCodedError($"{TaskPrefix}0001", ex.ToString());
+                Log.LogCodedError($"{TaskPrefix}0100", ex.ToString());
                 return false;
             }
         }

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/Gradle.cs
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/Gradle.cs
@@ -1,13 +1,14 @@
-﻿using Microsoft.Build.Framework;
-using System;
+﻿using System;
 using System.Diagnostics;
 using System.Runtime.InteropServices;
+
+using Microsoft.Build.Framework;
 
 namespace Microsoft.Maui.BindingExtensions.Build.Tasks
 {
     public class Gradle : BindingToolTask
     {
-        public override string TaskPrefix => "GDL";
+        public override string TaskPrefix => "GRDL";
 
         protected override string ToolName => RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? "gradlew.bat" : "gradlew";
 

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/Sharpie.cs
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/Sharpie.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Maui.BindingExtensions.Build.Tasks
+{
+    public class Sharpie : BindingToolTask
+    {
+        public override string TaskPrefix => "SHRP";
+
+        protected override string ToolName => "sharpie";
+
+
+        public string Arguments { get; set; } = string.Empty;
+
+
+        public Sharpie()
+        {
+        }
+
+        protected override string GenerateFullPathToTool()
+        {
+            return Path.Combine("/usr", "local", "bin", ToolExe);
+        }
+
+        protected override string GenerateCommandLineCommands() => Arguments;
+
+        public override bool RunTask()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                if (!File.Exists (GenerateFullPathToTool ())) {
+                    Log.LogCodedWarning($"{TaskPrefix}1000", "Unable to locate `sharpie`, please install https://aka.ms/objective-sharpie.");
+                    return false;
+                }
+
+                return base.RunTask();
+            }
+            else
+            {
+                Log.LogCodedWarning($"{TaskPrefix}1000", "sharpie is not currently supported on this platform. Please build this project on a macOS machine.");
+                return false;
+            }
+        }
+
+    }
+}

--- a/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/XcodeBuild.cs
+++ b/eng/src/Microsoft.Maui.BindingExtensions.Build.Tasks/Tasks/XcodeBuild.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+using Microsoft.Build.Framework;
+
+namespace Microsoft.Maui.BindingExtensions.Build.Tasks
+{
+    public class XcodeBuild : BindingToolTask
+    {
+        public override string TaskPrefix => "XCBD";
+
+        protected override string ToolName => "xcodebuild";
+
+
+        public string Arguments { get; set; } = string.Empty;
+
+
+        public XcodeBuild()
+        {
+        }
+
+        protected override string GenerateFullPathToTool()
+        {
+            return Path.Combine("/usr", "bin", ToolExe);
+        }
+
+        protected override string GenerateCommandLineCommands() => Arguments;
+
+        public override bool RunTask()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return base.RunTask();
+            }
+            else
+            {
+                Log.LogCodedWarning($"{TaskPrefix}1000", "xcodebuild is not currently supported on this platform. Please build this project on a macOS machine.");
+                return false;
+            }
+        }
+
+    }
+}

--- a/facebook/macios/Facebook.MaciOS.Binding/Facebook.MaciOS.Binding.csproj
+++ b/facebook/macios/Facebook.MaciOS.Binding/Facebook.MaciOS.Binding.csproj
@@ -1,22 +1,25 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net8.0-ios</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>true</ImplicitUsings>
-        <IsBindingProject>true</IsBindingProject>
+  <PropertyGroup>
+    <TargetFramework>net8.0-ios</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+  </PropertyGroup>
 
-        <XcodeProject>$(MSBuildThisFileDirectory)../native/MauiFacebook.xcodeproj</XcodeProject>
-        <ObjSharpieBindNamespace>Facebook</ObjSharpieBindNamespace>
-    </PropertyGroup>
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinitions.cs"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ObjcBindingApiDefinition Include="ApiDefinitions.cs"/>
-        <!-- <ObjcBindingCoreSource Include="StructsAndEnums.cs"/> -->
-        <NativeReference Include="../native/.build/MauiFacebook.xcframework">
-            <Kind>Framework</Kind>
-            <SmartLink>true</SmartLink>
-        </NativeReference>
-    </ItemGroup>
+  <ItemGroup>
+    <XcodeProjectReference Include="../native/MauiFacebook.xcodeproj">
+      <SchemeName>MauiFacebook</SchemeName>
+      <SharpieNamespace>Facebook</SharpieNamespace>
+      <SharpieBind>true</SharpieBind>
+      <!-- Metadata applicable to @(NativeReference) will be used if set -->
+      <Kind>Framework</Kind>
+      <SmartLink>true</SmartLink>
+    </XcodeProjectReference>
+  </ItemGroup>
 
-    <Import Project="$(MSBuildThisFileDirectory)..\..\..\eng\Common.macios.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\eng\Common.macios.targets" />
 </Project>

--- a/firebase/macios/Firebase.MaciOS.Binding/Firebase.MaciOS.Binding.csproj
+++ b/firebase/macios/Firebase.MaciOS.Binding/Firebase.MaciOS.Binding.csproj
@@ -1,24 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFrameworks>net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>true</ImplicitUsings>
-        <IsBindingProject>true</IsBindingProject>
-        <NoBindingEmbedding>true</NoBindingEmbedding>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0-ios;net8.0-maccatalyst</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+    <NoBindingEmbedding>true</NoBindingEmbedding>
+  </PropertyGroup>
 
-        <XcodeProject>$(MSBuildThisFileDirectory)../native/MauiFirebase.xcodeproj</XcodeProject>
-        <XcodeBuildXCFramework>true</XcodeBuildXCFramework>
-        <ObjSharpieBind>true</ObjSharpieBind>
-        <ObjSharpieBindNamespace>Firebase</ObjSharpieBindNamespace>
-    </PropertyGroup>
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />
-        <NativeReference Include="../native/.build/MauiFirebase.xcframework">
-            <Kind>Framework</Kind>
-            <SmartLink>true</SmartLink>
-        </NativeReference>
-    </ItemGroup>
+  <ItemGroup>
+    <XcodeProjectReference Include="../native/MauiFirebase.xcodeproj">
+      <SchemeName>MauiFirebase</SchemeName>
+      <SharpieNamespace>Firebase</SharpieNamespace>
+      <SharpieBind>true</SharpieBind>
+      <!-- Metadata applicable to @(NativeReference) will be used if set -->
+      <Kind>Framework</Kind>
+      <SmartLink>true</SmartLink>
+    </XcodeProjectReference>
+  </ItemGroup>
 
-    <Import Project="$(MSBuildThisFileDirectory)..\..\..\eng\Common.macios.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\eng\Common.macios.targets" />
 </Project>

--- a/googlecast/macios/GoogleCast.Binding/GoogleCast.Binding.csproj
+++ b/googlecast/macios/GoogleCast.Binding/GoogleCast.Binding.csproj
@@ -1,41 +1,41 @@
 <Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0-ios</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>true</ImplicitUsings>
+    <IsBindingProject>true</IsBindingProject>
+
+    <XcodeBuildMacCatalyst>False</XcodeBuildMacCatalyst>
+    <BuildXcodeProjectsDependsOnTargets>$(BuildXcodeProjectsDependsOnTargets);NativeDependencies</BuildXcodeProjectsDependsOnTargets>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <XcodeProjectReference Include="../native/MauiGoogleCast.xcodeproj">
+      <SchemeName>MauiGoogleCast</SchemeName>
+      <SharpieNamespace>GoogleCast</SharpieNamespace>
+      <SharpieBind>false</SharpieBind>
+      <!-- Metadata applicable to @(NativeReference) will be used if set -->
+      <Kind>Framework</Kind>
+      <SmartLink>true</SmartLink>
+    </XcodeProjectReference>
+  </ItemGroup>
+
+  <Target Name="NativeDependencies">
     <PropertyGroup>
-        <TargetFramework>net8.0-ios</TargetFramework>
-        <Nullable>enable</Nullable>
-        <ImplicitUsings>true</ImplicitUsings>
-        <IsBindingProject>true</IsBindingProject>
+      <GoogleCastiOSSdkVersion>4.8.0</GoogleCastiOSSdkVersion>
+      <GoogleCastiOSSdkUrl>https://dl.google.com/dl/chromecast/sdk/ios/GoogleCastSDK-ios-$(GoogleCastiOSSdkVersion)_dynamic_xcframework.zip</GoogleCastiOSSdkUrl>
     </PropertyGroup>
 
-    <ItemGroup>
-        <ObjcBindingApiDefinition Include="ApiDefinitions.cs" />
-        <!-- <ObjcBindingCoreSource Include="StructsAndEnums.cs"/> -->
-        <NativeReference Include="../native/.build/MauiGoogleCast.xcframework">
-            <Kind>Framework</Kind>
-            <SmartLink>True</SmartLink>
-        </NativeReference>
-    </ItemGroup>
+    <DownloadFile SourceUrl="$(GoogleCastiOSSdkUrl)" DestinationFolder="$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/build/deps))">
+      <Output TaskParameter="DownloadedFile" ItemName="GoogleCastiOSSdkArchives" />
+    </DownloadFile>
 
-    <PropertyGroup>
-        <XcodeBuildMacCatalyst>False</XcodeBuildMacCatalyst>
-        <XcodeProject>$(MSBuildThisFileDirectory)../native/MauiGoogleCast.xcodeproj</XcodeProject>
-        <XcodeBuildXCFramework>true</XcodeBuildXCFramework>
-        <ObjSharpieBind>False</ObjSharpieBind>
-        <ObjSharpieBindNamespace>GoogleCast</ObjSharpieBindNamespace>
-        <BuildXCFrameworkDependsOnTargets>$(BuildXCFrameworkDependsOnTargets);NativeDependencies</BuildXCFrameworkDependsOnTargets>
-    </PropertyGroup>
+    <Exec Command="unzip -q -o -d $([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/build/deps)) @(GoogleCastiOSSdkArchives)" />
+  </Target>
 
-    <Target Name="NativeDependencies">
-        <PropertyGroup>
-            <GoogleCastiOSSdkVersion>4.8.0</GoogleCastiOSSdkVersion>
-            <GoogleCastiOSSdkUrl>https://dl.google.com/dl/chromecast/sdk/ios/GoogleCastSDK-ios-$(GoogleCastiOSSdkVersion)_dynamic_xcframework.zip</GoogleCastiOSSdkUrl>
-        </PropertyGroup>
-
-        <DownloadFile SourceUrl="$(GoogleCastiOSSdkUrl)" DestinationFolder="$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/.build))">
-            <Output TaskParameter="DownloadedFile" ItemName="GoogleCastiOSSdkArchives" />
-        </DownloadFile>
-
-        <Exec Command="unzip -o -d $([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/.build)) @(GoogleCastiOSSdkArchives)" />
-    </Target>
-
-    <Import Project="$(MSBuildThisFileDirectory)..\..\..\eng\Common.macios.targets" />
+  <Import Project="$(MSBuildThisFileDirectory)..\..\..\eng\Common.macios.targets" />
 </Project>

--- a/googlecast/macios/native/MauiGoogleCast.xcodeproj/project.pbxproj
+++ b/googlecast/macios/native/MauiGoogleCast.xcodeproj/project.pbxproj
@@ -7,20 +7,20 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		640AD22E2BBE1D02005FB56B /* GoogleCast.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 640AD22D2BBE1D02005FB56B /* GoogleCast.xcframework */; };
-		640AD22F2BBE1D02005FB56B /* GoogleCast.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 640AD22D2BBE1D02005FB56B /* GoogleCast.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		64B9934B2B97A71D00BAFB55 /* MauiGoogleCast.h in Headers */ = {isa = PBXBuildFile; fileRef = 64B9934A2B97A71D00BAFB55 /* MauiGoogleCast.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		64B993572B97A7B300BAFB55 /* MauiGoogleCast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64B993562B97A7B300BAFB55 /* MauiGoogleCast.swift */; };
+		D0D666252C06BE5F005451D1 /* GoogleCast.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = D0D666232C06BD7B005451D1 /* GoogleCast.xcframework */; };
+		D0D666262C06BE5F005451D1 /* GoogleCast.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = D0D666232C06BD7B005451D1 /* GoogleCast.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
-		640AD2302BBE1D02005FB56B /* Embed Frameworks */ = {
+		D0D666272C06BE5F005451D1 /* Embed Frameworks */ = {
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				640AD22F2BBE1D02005FB56B /* GoogleCast.xcframework in Embed Frameworks */,
+				D0D666262C06BE5F005451D1 /* GoogleCast.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -28,10 +28,10 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		640AD22D2BBE1D02005FB56B /* GoogleCast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleCast.xcframework; path = ".build/GoogleCastSDK-ios-4.8.0_dynamic_xcframework/GoogleCast.xcframework"; sourceTree = "<group>"; };
 		64B993472B97A71D00BAFB55 /* MauiGoogleCast.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MauiGoogleCast.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		64B9934A2B97A71D00BAFB55 /* MauiGoogleCast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MauiGoogleCast.h; sourceTree = "<group>"; };
 		64B993562B97A7B300BAFB55 /* MauiGoogleCast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MauiGoogleCast.swift; sourceTree = "<group>"; };
+		D0D666232C06BD7B005451D1 /* GoogleCast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleCast.xcframework; path = "build/deps/GoogleCastSDK-ios-4.8.0_dynamic_xcframework/GoogleCast.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -39,7 +39,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				640AD22E2BBE1D02005FB56B /* GoogleCast.xcframework in Frameworks */,
+				D0D666252C06BE5F005451D1 /* GoogleCast.xcframework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -75,7 +75,7 @@
 		64B993512B97A7A200BAFB55 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				640AD22D2BBE1D02005FB56B /* GoogleCast.xcframework */,
+				D0D666232C06BD7B005451D1 /* GoogleCast.xcframework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -102,7 +102,7 @@
 				64B993432B97A71D00BAFB55 /* Sources */,
 				64B993442B97A71D00BAFB55 /* Frameworks */,
 				64B993452B97A71D00BAFB55 /* Resources */,
-				640AD2302BBE1D02005FB56B /* Embed Frameworks */,
+				D0D666272C06BE5F005451D1 /* Embed Frameworks */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
Introduces a new `@(XcodeProjectReference)` item to help simplify the
content that needs to be added to the binding .csproj file.  This item
will translate relevant metadata to the `@(NativeReference)` item that
is automatically added to the project after the xcode project is built.

Build task wrappers for `xcodebuild` and `sharpie` have been added to
improve msbuild output and error logging when a tool invocation fails.