### PR TITLE
[buildtasks] Add classic XI install check to sharpie

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,13 @@ jobs:
       - name: Install MAUI
         run: dotnet workload install maui
 
-      - name: Install objectivesharpie
+      - name: Install boots
+        run: dotnet tool update -v:d boots --version 1.1.0.36 --add-source "https://api.nuget.org/v3/index.json" --global
+
+      - name: Install Classic XI
+        run: boots https://download.visualstudio.microsoft.com/download/pr/ceb0ea3f-4db8-46b4-8dc3-8049d27c0107/3960868aa9b1946a6c77668c3f3334ee/xamarin.ios-16.4.0.23.pkg
+
+      - name: Install Sharpie
         run: brew install objectivesharpie
 
       - name: Create logs dir

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <MSBuildPackageVersion>17.9.5</MSBuildPackageVersion>
-    <BindingExtPackageVersion>0.0.1-pre1</BindingExtPackageVersion>
+    <BindingExtPackageVersion>0.0.1-pre2</BindingExtPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <MSBuildPackageVersion>17.9.5</MSBuildPackageVersion>
-    <BindingExtPackageVersion>0.0.1-pre2</BindingExtPackageVersion>
+    <BindingExtPackageVersion>0.0.1-pre3</BindingExtPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="maui-binding-extensions" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/maui-binding-extensions/nuget/v3/index.json" />
-    <add key="local" value="src/CommunityToolkit.Maui.BindingExtensions/bin/Release/" />
+    <!--add key="local" value="src/CommunityToolkit.Maui.BindingExtensions/bin/Release/" /-->
   </packageSources>
 </configuration>

--- a/src/CommunityToolkit.Maui.BindingExtensions.Tests/MockBuildEngine.cs
+++ b/src/CommunityToolkit.Maui.BindingExtensions.Tests/MockBuildEngine.cs
@@ -28,7 +28,7 @@ namespace CommunityToolkit.Maui.BindingExtensions.Tests
 
         public bool IsRunningMultipleNodes => false;
 
-        public TextWriter Output { get; set; } = TestContext.Out;
+        public TextWriter Output { get; set; } = Console.Out;
 
         public void ClearEvents()
         {

--- a/src/CommunityToolkit.Maui.BindingExtensions.Tests/SharpieTaskTests.cs
+++ b/src/CommunityToolkit.Maui.BindingExtensions.Tests/SharpieTaskTests.cs
@@ -1,0 +1,32 @@
+﻿using FluentAssertions;
+using CommunityToolkit.Maui.BindingExtensions;
+using NUnit.Framework;
+
+namespace CommunityToolkit.Maui.BindingExtensions.Tests
+{
+    [TestFixture]
+    public class SharpieTaskTests
+    {
+        MockBuildEngine engine = new MockBuildEngine();
+
+        [SetUp]
+        public void Setup()
+        {
+            engine.ClearEvents();
+        }
+
+        [Test]
+        public void ShouldRunSuccessfully()
+        {
+            var task = new Sharpie()
+            {
+                BuildEngine = engine,
+                Arguments = "xcode -sdks",
+            };
+
+            var taskSucceeded = task.Execute();
+            taskSucceeded.Should().Be(true, "Task should complete successfully.");
+            task.ConsoleOutput.Should().Contain("iphoneos", "Sharpie 'xcode -sdks' output should contain at least one 'iphoneos' entry.");
+        }
+    }
+}

--- a/src/CommunityToolkit.Maui.BindingExtensions.Tests/SharpieTaskTests.cs
+++ b/src/CommunityToolkit.Maui.BindingExtensions.Tests/SharpieTaskTests.cs
@@ -21,7 +21,7 @@ namespace CommunityToolkit.Maui.BindingExtensions.Tests
             var task = new Sharpie()
             {
                 BuildEngine = engine,
-                Arguments = "xcode -sdks",
+                Arguments = "xcode -sdks -x /Applications/Xcode.app",
             };
 
             var taskSucceeded = task.Execute();

--- a/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
+++ b/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
@@ -21,7 +21,7 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>0.0.1-pre1</Version>
+    <Version>0.0.1-pre2</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>net,maui,netmaui,toolkit,kit,communitytoolkit,netmauitoolkit,mauicommunitytoolkit,slimbinding,binding</PackageTags>

--- a/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
+++ b/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
@@ -21,7 +21,7 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>0.0.1-pre2</Version>
+    <Version>0.0.1-pre3</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>net,maui,netmaui,toolkit,kit,communitytoolkit,netmauitoolkit,mauicommunitytoolkit,slimbinding,binding</PackageTags>

--- a/src/CommunityToolkit.Maui.BindingExtensions/Tasks/Sharpie.cs
+++ b/src/CommunityToolkit.Maui.BindingExtensions/Tasks/Sharpie.cs
@@ -32,12 +32,12 @@ namespace CommunityToolkit.Maui.BindingExtensions
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 if (!File.Exists (GenerateFullPathToTool ())) {
-                    Log.LogCodedWarning($"{TaskPrefix}1000", "Unable to run `sharpie`, please install Objective-Sharpie. https://aka.ms/objective-sharpie.");
+                    Log.LogCodedError($"{TaskPrefix}1000", "Unable to run `sharpie`, please install Objective-Sharpie. https://aka.ms/objective-sharpie.");
                     return false;
                 }
 
                 if (!File.Exists (ClassicXIAssembly)) {
-                    Log.LogCodedWarning($"{TaskPrefix}1000", "Unable to run `sharpie`, please install Xamarin.iOS. https://github.com/xamarin/xamarin-macios/blob/main/DOWNLOADS.md");
+                    Log.LogCodedError($"{TaskPrefix}1001", "Unable to run `sharpie`, please install Xamarin.iOS. https://github.com/xamarin/xamarin-macios/blob/main/DOWNLOADS.md");
                     return false;
                 }
 
@@ -45,7 +45,7 @@ namespace CommunityToolkit.Maui.BindingExtensions
             }
             else
             {
-                Log.LogCodedWarning($"{TaskPrefix}1001", "Unable to run `sharpie` on this platform. Please build this project on a macOS machine.");
+                Log.LogCodedWarning($"{TaskPrefix}1010", "Unable to run `sharpie` on this platform. Please build this project on a macOS machine.");
                 return true;
             }
         }

--- a/src/CommunityToolkit.Maui.BindingExtensions/Tasks/Sharpie.cs
+++ b/src/CommunityToolkit.Maui.BindingExtensions/Tasks/Sharpie.cs
@@ -11,9 +11,10 @@ namespace CommunityToolkit.Maui.BindingExtensions
 
         protected override string ToolName => "sharpie";
 
-
         public string Arguments { get; set; } = string.Empty;
 
+
+        const string ClassicXIAssembly = "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/64bits/iOS/Xamarin.iOS.dll";
 
         public Sharpie()
         {
@@ -31,7 +32,12 @@ namespace CommunityToolkit.Maui.BindingExtensions
             if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
             {
                 if (!File.Exists (GenerateFullPathToTool ())) {
-                    Log.LogCodedWarning($"{TaskPrefix}1000", "Unable to locate `sharpie`, please install https://aka.ms/objective-sharpie.");
+                    Log.LogCodedWarning($"{TaskPrefix}1000", "Unable to run `sharpie`, please install Objective-Sharpie. https://aka.ms/objective-sharpie.");
+                    return false;
+                }
+
+                if (!File.Exists (ClassicXIAssembly)) {
+                    Log.LogCodedWarning($"{TaskPrefix}1000", "Unable to run `sharpie`, please install Xamarin.iOS. https://github.com/xamarin/xamarin-macios/blob/main/DOWNLOADS.md");
                     return false;
                 }
 
@@ -39,8 +45,8 @@ namespace CommunityToolkit.Maui.BindingExtensions
             }
             else
             {
-                Log.LogCodedWarning($"{TaskPrefix}1000", "sharpie is not currently supported on this platform. Please build this project on a macOS machine.");
-                return false;
+                Log.LogCodedWarning($"{TaskPrefix}1001", "Unable to run `sharpie` on this platform. Please build this project on a macOS machine.");
+                return true;
             }
         }
 

--- a/src/CommunityToolkit.Maui.BindingExtensions/Tasks/XcodeBuild.cs
+++ b/src/CommunityToolkit.Maui.BindingExtensions/Tasks/XcodeBuild.cs
@@ -34,7 +34,7 @@ namespace CommunityToolkit.Maui.BindingExtensions
             }
             else
             {
-                Log.LogCodedWarning($"{TaskPrefix}1000", "xcodebuild is not currently supported on this platform. Please build this project on a macOS machine.");
+                Log.LogCodedError($"{TaskPrefix}1000", "xcodebuild is not currently supported on this platform. Please build this project on a macOS machine.");
                 return false;
             }
         }

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -46,7 +46,7 @@
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.pbxproj" />
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.xcworkspace"/>
       <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectBuildDirectory)/**/*')" />
-      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/BuildXcodeFramework.stamp')" />
+      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/_BuildXcodeProjects.stamp')" />
     </ItemGroup>
   </Target>
 
@@ -101,10 +101,7 @@
     <Error Condition=" !Exists('@(NativeReference)') " Text="Xcode project built successfully but did not produce expected output file: '@(NativeReference)'" />
     <Message Text="Adding reference to Xcode project output: @(NativeReference)" />
 
-    <ItemGroup>
-      <FileWrites Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectBuildDirectory)/**/*" />
-    </ItemGroup>
-    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/BuildXcodeFramework.stamp')" AlwaysCreate="true" />
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
   </Target>
 
 

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -119,16 +119,27 @@
       Inputs="@(_SharpieInputs)"
       Outputs="@(_SharpieOutputs)">
 
-    <Sharpie Arguments="xcode -sdks" >
+    <Exec Command="xcode-select -p"
+        Condition="$([MSBuild]::IsOSPlatform('osx'))"
+        ConsoleToMSBuild="true"
+        StandardOutputImportance="low">
+      <Output TaskParameter="ConsoleOutput" PropertyName="_XcodeSelectOutput" />
+    </Exec>
+
+    <PropertyGroup>
+      <SharpieXcodeFilter Condition=" '$(SharpieXcodeFilter)' == '' and '$(_XcodeSelectOutput)' != '' ">-x $(_XcodeSelectOutput.Replace(Contents/Developer, ''))</SharpieXcodeFilter>
+    </PropertyGroup>
+
+    <Sharpie Arguments="xcode -sdks $(SharpieXcodeFilter)" >
       <Output TaskParameter="ConsoleOutput" PropertyName="_SharpieXcodeSdksOutput" />
     </Sharpie>
 
     <PropertyGroup>
-      <_SharpieBindXcodeSdkName Condition=" '$(_SharpieBindXcodeSdkName)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(_SharpieXcodeSdksOutput), `iphoneos[^; \n\r\t]+`))</_SharpieBindXcodeSdkName>
+      <SharpieSdkName Condition=" '$(SharpieBindXcodeSdkName)' == '' ">$([System.Text.RegularExpressions.Regex]::Match($(_SharpieXcodeSdksOutput), `iphoneos[^; \n\r\t]+`))</SharpieSdkName>
     </PropertyGroup>
 
     <ItemGroup>
-      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--output=&quot;%(RootDir)%(Directory)build/sharpie&quot; --namespace=%(SharpieNamespace) --sdk=$(_SharpieBindXcodeSdkName)')" />
+      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--output=&quot;%(RootDir)%(Directory)build/sharpie&quot; --namespace=%(SharpieNamespace) --sdk=$(SharpieSdkName)')" />
       <_ObjSharpieArgs Condition=" '$(XcodeBuildiOS)' == 'true' "
           Include="@(XcodeProjectReference->'--scope=&quot;%(XCArchiveiOS)/Products/Library/Frameworks/%(SchemeName).framework/Headers&quot; &quot;%(XCArchiveiOS)/Products/Library/Frameworks/%(SchemeName).framework/Headers/%(SchemeName)-Swift.h&quot;')" />
       <_ObjSharpieArgs Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -165,7 +165,7 @@
 
   <Target Name="_CleanXcodeProjects"
       Condition=" '@(XcodeProjectReference->Count())' != '0' ">
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)')" />
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)')" />
   </Target>
 
 </Project>


### PR DESCRIPTION
Sharpie requires XI, add a check for it and update provisioning steps.

$(SharpieXcodeFilter) has been added to filter the list of sdks sharpie will use.