### PR TITLE
Use `bin` as default output dir for native projects

### DIFF
--- a/facebook/android/Facebook.Android.Binding/Facebook.Android.Binding.csproj
+++ b/facebook/android/Facebook.Android.Binding/Facebook.Android.Binding.csproj
@@ -12,12 +12,13 @@
     <PackageReference Include="CommunityToolkit.Maui.BindingExtensions" Version="$(BindingExtPackageVersion)" />
   </ItemGroup>
 
-  <!-- Metadata applicable to @(AndroidLibrary) will be used if set -->
   <ItemGroup>
     <GradleProjectReference Include="../native" >
       <ModuleName>mauifacebook</ModuleName>
+      <!-- Metadata applicable to @(AndroidLibrary) will be used if set, otherwise the following defaults will be used:
       <Bind>true</Bind>
       <Pack>true</Pack>
+      -->
     </GradleProjectReference>
   </ItemGroup>
 

--- a/facebook/android/native/mauifacebook/build.gradle.kts
+++ b/facebook/android/native/mauifacebook/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
 project.afterEvaluate {
     tasks.register<Copy>("copyDeps") {
         from(configurations["copyDependencies"])
-        into("${projectDir}/build/outputs/deps")
+        into("${buildDir}/outputs/deps")
     }
     tasks.named("preBuild") { finalizedBy("copyDeps") }
 }

--- a/facebook/macios/Facebook.MaciOS.Binding/Facebook.MaciOS.Binding.csproj
+++ b/facebook/macios/Facebook.MaciOS.Binding/Facebook.MaciOS.Binding.csproj
@@ -16,9 +16,10 @@
       <SchemeName>MauiFacebook</SchemeName>
       <SharpieNamespace>Facebook</SharpieNamespace>
       <SharpieBind>true</SharpieBind>
-      <!-- Metadata applicable to @(NativeReference) will be used if set -->
+      <!-- Metadata applicable to @(NativeReference) will be used if set, otherwise the following defaults will be used:
       <Kind>Framework</Kind>
       <SmartLink>true</SmartLink>
+      -->
     </XcodeProjectReference>
   </ItemGroup>
 

--- a/facebook/sample/Sample.csproj
+++ b/facebook/sample/Sample.csproj
@@ -64,15 +64,15 @@
     <ItemGroup Condition="$(TargetFramework.Contains('android'))">
         <ProjectReference Include="..\android\Facebook.Android.Binding\Facebook.Android.Binding.csproj" />
         <!-- Include core facebook dependencies. Starting in .NET 9 these can potentially be replaced with @(AndroidMavenPackage) -->
-        <AndroidLibrary Include="..\android\native\mauifacebook\build\outputs\deps\facebook-android-sdk*.aar">
+        <AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-android-sdk-17.0.0.aar">
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>
-        <AndroidLibrary Include="..\android\native\mauifacebook\build\outputs\deps\facebook-common*.aar">
+        <AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-common-17.0.0.aar">
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>
-        <AndroidLibrary Include="..\android\native\mauifacebook\build\outputs\deps\facebook-core*.aar">
+        <AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-core-17.0.0.aar">
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>

--- a/firebase/macios/Firebase.MaciOS.Binding/Firebase.MaciOS.Binding.csproj
+++ b/firebase/macios/Firebase.MaciOS.Binding/Firebase.MaciOS.Binding.csproj
@@ -17,9 +17,10 @@
       <SchemeName>MauiFirebase</SchemeName>
       <SharpieNamespace>Firebase</SharpieNamespace>
       <SharpieBind>true</SharpieBind>
-      <!-- Metadata applicable to @(NativeReference) will be used if set -->
+      <!-- Metadata applicable to @(NativeReference) will be used if set, otherwise the following defaults will be used:
       <Kind>Framework</Kind>
       <SmartLink>true</SmartLink>
+      -->
     </XcodeProjectReference>
   </ItemGroup>
 

--- a/googlecast/macios/GoogleCast.Binding/GoogleCast.Binding.csproj
+++ b/googlecast/macios/GoogleCast.Binding/GoogleCast.Binding.csproj
@@ -18,9 +18,10 @@
       <SchemeName>MauiGoogleCast</SchemeName>
       <SharpieNamespace>GoogleCast</SharpieNamespace>
       <SharpieBind>false</SharpieBind>
-      <!-- Metadata applicable to @(NativeReference) will be used if set -->
+      <!-- Metadata applicable to @(NativeReference) will be used if set, otherwise the following defaults will be used:
       <Kind>Framework</Kind>
       <SmartLink>true</SmartLink>
+      -->
     </XcodeProjectReference>
   </ItemGroup>
 

--- a/googlecast/macios/GoogleCast.Binding/GoogleCast.Binding.csproj
+++ b/googlecast/macios/GoogleCast.Binding/GoogleCast.Binding.csproj
@@ -37,11 +37,11 @@
       <GoogleCastiOSSdkUrl>https://github.com/react-native-google-cast/google-cast-sdk-dynamic-xcframework-no-bluetooth/archive/refs/tags/4.7.1.zip</GoogleCastiOSSdkUrl>
     </PropertyGroup>
 
-    <DownloadFile SourceUrl="$(GoogleCastiOSSdkUrl)" DestinationFolder="$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/build/deps))">
+    <DownloadFile SourceUrl="$(GoogleCastiOSSdkUrl)" DestinationFolder="$([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/bin/deps))">
       <Output TaskParameter="DownloadedFile" ItemName="GoogleCastiOSSdkArchives" />
     </DownloadFile>
 
-    <Exec Command="unzip -q -o -d $([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/build/deps)) @(GoogleCastiOSSdkArchives)" />
+    <Exec Command="unzip -q -o -d $([System.IO.Path]::GetFullPath($(MSBuildProjectDirectory)/../native/bin/deps)) @(GoogleCastiOSSdkArchives)" />
   </Target>
 
 </Project>

--- a/googlecast/macios/native/MauiGoogleCast.xcodeproj/project.pbxproj
+++ b/googlecast/macios/native/MauiGoogleCast.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		64B993472B97A71D00BAFB55 /* MauiGoogleCast.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MauiGoogleCast.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		64B9934A2B97A71D00BAFB55 /* MauiGoogleCast.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MauiGoogleCast.h; sourceTree = "<group>"; };
 		64B993562B97A7B300BAFB55 /* MauiGoogleCast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MauiGoogleCast.swift; sourceTree = "<group>"; };
-		D0A597A42C211EE600C52635 /* GoogleCast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleCast.xcframework; path = "build/deps/google-cast-sdk-dynamic-xcframework-no-bluetooth-4.7.1/GoogleCast.xcframework"; sourceTree = "<group>"; };
+		D0A597A42C211EE600C52635 /* GoogleCast.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = GoogleCast.xcframework; path = "bin/deps/google-cast-sdk-dynamic-xcframework-no-bluetooth-4.7.1/GoogleCast.xcframework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */

--- a/nuget.config
+++ b/nuget.config
@@ -2,6 +2,6 @@
 <configuration>
   <packageSources>
     <add key="maui-binding-extensions" value="https://pkgs.dev.azure.com/xamarin/public/_packaging/maui-binding-extensions/nuget/v3/index.json" />
-    <!--add key="local" value="src/CommunityToolkit.Maui.BindingExtensions/bin/Release/" /-->
+    <add key="local" value="src/CommunityToolkit.Maui.BindingExtensions/bin/Release/" />
   </packageSources>
 </configuration>

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.android.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.android.targets
@@ -5,6 +5,7 @@
 
   <PropertyGroup>
     <GradleProjectConfiguration Condition=" '$(GradleProjectConfiguration)' == '' ">Release</GradleProjectConfiguration>
+    <GradleProjectBuildDirectory Condition=" '$(GradleProjectBuildDirectory)' == '' ">bin</GradleProjectBuildDirectory>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -32,8 +33,8 @@
       <_GradleInputs Include="%(GradleProjectReference.FullPath)/**/*.gradle" />
       <_GradleInputs Include="%(GradleProjectReference.FullPath)/**/*.xml" />
       <_GradleInputs Include="%(GradleProjectReference.FullPath)/**/*.properties"/>
-      <_GradleInputs Remove="%(GradleProjectReference.FullPath)/%(GradleProjectReference.ModuleName)/build/**/*" />
-      <_GradleOutputs Include="@(GradleProjectReference->'%(FullPath)/%(ModuleName)/build/outputs/aar/%(ModuleName)-$(GradleProjectConfiguration).aar')" />
+      <_GradleInputs Remove="%(GradleProjectReference.FullPath)/%(GradleProjectReference.ModuleName)/$(GradleProjectBuildDirectory)/**/*" />
+      <_GradleOutputs Include="@(GradleProjectReference->'%(FullPath)/%(ModuleName)/$(GradleProjectBuildDirectory)/outputs/aar/%(ModuleName)-$(GradleProjectConfiguration).aar')" />
     </ItemGroup>
   </Target>
 
@@ -44,12 +45,12 @@
       Inputs="@(_GradleInputs)"
       Outputs="@(_GradleOutputs)" >
     
-    <RemoveDir Directories="@(GradleProjectReference->'%(FullPath)/%(ModuleName)/build/outputs')" />
+    <RemoveDir Directories="@(GradleProjectReference->'%(FullPath)/%(ModuleName)/$(GradleProjectBuildDirectory)/outputs')" />
 
     <Gradle ToolPath="%(GradleProjectReference.FullPath)"
         AndroidSdkDirectory="$(AndroidSdkDirectory)"
         JavaSdkDirectory="$(JavaSdkDirectory)"
-        Arguments="%(GradleProjectReference.ModuleName):assemble$(GradleProjectConfiguration)"
+        Arguments="%(GradleProjectReference.ModuleName):assemble$(GradleProjectConfiguration) -Dorg.gradle.project.buildDir=$(GradleProjectBuildDirectory)"
         WorkingDirectory="%(GradleProjectReference.FullPath)" >
     </Gradle>
 
@@ -63,6 +64,23 @@
 
     <Error Condition=" !Exists('@(AndroidLibrary)') " Text="Gradle project built successfully but did not produce expected output file: '@(AndroidLibrary)'" />
     <Message Text="Adding reference to gradle project output: @(AndroidLibrary)" />
+  </Target>
+
+
+  <!-- Consider also moving native build outputs to $(IntermediateOutputDirectory) and using @(FileWrites) to clean -->
+  <PropertyGroup>
+    <CleanDependsOn>
+      $(CleanDependsOn);
+      _CleanGradleProjects;
+    </CleanDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_CleanGradleProjects"
+      Condition=" '@(GradleProjectReference->Count())' != '0' " >
+    <Gradle ToolPath="%(GradleProjectReference.FullPath)"
+        Arguments="clean -Dorg.gradle.project.buildDir=$(GradleProjectBuildDirectory)"
+        WorkingDirectory="%(GradleProjectReference.FullPath)" >
+    </Gradle>
   </Target>
 
 </Project>

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -6,6 +6,8 @@
 
   <PropertyGroup>
     <XcodeProjectConfiguration Condition=" '$(XcodeProjectConfiguration)' == '' ">Release</XcodeProjectConfiguration>
+    <XcodeProjectBuildDirectory Condition=" '$(XcodeProjectBuildDirectory)' == '' ">bin</XcodeProjectBuildDirectory>
+
     <XcodeBuildiOS Condition=" '$(XcodeBuildiOS)' == '' and ($(TargetFrameworks.Contains('ios')) or $(TargetFramework.Contains('ios'))) ">true</XcodeBuildiOS>
     <XcodeBuildiOSSimulator Condition=" '$(XcodeBuildiOSSimulator)' == '' and ($(TargetFrameworks.Contains('ios')) or $(TargetFramework.Contains('ios'))) ">true</XcodeBuildiOSSimulator>
     <XcodeBuildMacCatalyst Condition=" '$(XcodeBuildMacCatalyst)' == '' and ($(TargetFrameworks.Contains('maccatalyst')) or $(TargetFramework.Contains('maccatalyst'))) ">true</XcodeBuildMacCatalyst>
@@ -20,9 +22,9 @@
     <XcodeProjectReference>
       <Kind>Framework</Kind>
       <SmartLink>true</SmartLink>
-      <XCArchiveiOS>%(RootDir)%(Directory)build/%(Filename)/ios.xcarchive</XCArchiveiOS>
-      <XCArchiveiOSSimulator>%(RootDir)%(Directory)build/%(Filename)/iossimulator.xcarchive</XCArchiveiOSSimulator>
-      <XCArchiveMacCatalyst>%(RootDir)%(Directory)build/%(Filename)/maccatalyst.xcarchive</XCArchiveMacCatalyst>
+      <XCArchiveiOS>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/ios.xcarchive</XCArchiveiOS>
+      <XCArchiveiOSSimulator>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/iossimulator.xcarchive</XCArchiveiOSSimulator>
+      <XCArchiveMacCatalyst>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/maccatalyst.xcarchive</XCArchiveMacCatalyst>
     </XcodeProjectReference>
   </ItemDefinitionGroup>
 
@@ -43,8 +45,8 @@
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.h" />
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.pbxproj" />
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.xcworkspace"/>
-      <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)build/**/*')" />
-      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(Filename)/BuildXcodeFramework.stamp')" />
+      <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectBuildDirectory)/**/*')" />
+      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/BuildXcodeFramework.stamp')" />
     </ItemGroup>
   </Target>
 
@@ -55,7 +57,7 @@
       Inputs="@(_XcbInputs)"
       Outputs="@(_XcbOutputs)" >
 
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(Filename)')" />
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)')" />
 
     <!-- Create xcarchive files for configured platforms -->
     <XcodeBuild Condition=" '$(XcodeBuildiOS)' == 'true' "
@@ -82,7 +84,7 @@
           Include="@(XcodeProjectReference->'-archive %(XCArchiveiOSSimulator) -framework %(SchemeName).framework')" />
       <_CreateXcFxArgs Condition=" '$(XcodeBuildMacCatalyst)' == 'true' "
           Include="@(XcodeProjectReference->'-archive %(XCArchiveMacCatalyst) -framework %(SchemeName).framework')" />
-      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)build/%(Filename)/%(SchemeName).xcframework')" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/%(SchemeName).xcframework')" />
     </ItemGroup>
 
     <XcodeBuild Arguments="@(_CreateXcFxArgs, ' ')"
@@ -90,7 +92,7 @@
     </XcodeBuild>
 
     <ItemGroup>
-      <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(Filename)/%(SchemeName).xcframework')">
+      <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/%(SchemeName).xcframework')">
         <Kind>%(XcodeProjectReference.Kind)</Kind>
         <SmartLink>%(XcodeProjectReference.SmartLink)</SmartLink>
       </NativeReference>
@@ -98,7 +100,11 @@
 
     <Error Condition=" !Exists('@(NativeReference)') " Text="Xcode project built successfully but did not produce expected output file: '@(NativeReference)'" />
     <Message Text="Adding reference to Xcode project output: @(NativeReference)" />
-    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)build/%(Filename)/BuildXcodeFramework.stamp')" AlwaysCreate="true" />
+
+    <ItemGroup>
+      <FileWrites Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectBuildDirectory)/**/*" />
+    </ItemGroup>
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/BuildXcodeFramework.stamp')" AlwaysCreate="true" />
   </Target>
 
 
@@ -108,7 +114,7 @@
           Include="%(XcodeProjectReference.XCArchiveiOS)/**/*.*" />
       <_SharpieInputs Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "
           Include="%(XcodeProjectReference.XCArchiveMacCatalyst)/**/*.*" />
-      <_SharpieOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)build/sharpie/_SharpieBindXcodeProjects.stamp')" />
+      <_SharpieOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/_SharpieBindXcodeProjects.stamp')" />
     </ItemGroup>
   </Target>
 
@@ -128,7 +134,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--output=&quot;%(RootDir)%(Directory)build/sharpie&quot; --namespace=%(SharpieNamespace) --sdk=$(_SharpieBindXcodeSdkName)')" />
+      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--output=&quot;%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie&quot; --namespace=%(SharpieNamespace) --sdk=$(_SharpieBindXcodeSdkName)')" />
       <_ObjSharpieArgs Condition=" '$(XcodeBuildiOS)' == 'true' "
           Include="@(XcodeProjectReference->'--scope=&quot;%(XCArchiveiOS)/Products/Library/Frameworks/%(SchemeName).framework/Headers&quot; &quot;%(XCArchiveiOS)/Products/Library/Frameworks/%(SchemeName).framework/Headers/%(SchemeName)-Swift.h&quot;')" />
       <_ObjSharpieArgs Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "
@@ -137,7 +143,21 @@
 
     <Sharpie Arguments="bind @(_ObjSharpieArgs, ' ')" />
 
-    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)build/sharpie/_SharpieBindXcodeProjects.stamp')" AlwaysCreate="true" />
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/_SharpieBindXcodeProjects.stamp')" AlwaysCreate="true" />
+  </Target>
+
+
+  <!-- Consider also moving native build outputs to $(IntermediateOutputDirectory) and using @(FileWrites) to clean -->
+  <PropertyGroup>
+    <CleanDependsOn>
+      $(CleanDependsOn);
+      _CleanXcodeProjects;
+    </CleanDependsOn>
+  </PropertyGroup>
+
+  <Target Name="_CleanXcodeProjects"
+      Condition=" '@(XcodeProjectReference->Count())' != '0' ">
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)')" />
   </Target>
 
 </Project>


### PR DESCRIPTION
`$(GradleProjectBuildDirectory)` and `$(XcodeProjectBuildDirectory)`
props have been added to control the name of the output directory of
native builds. The default value is now `bin`, to better match .NET
project outputs.

The android and macios targets now hook into the Clean target to ensure
native project outputs are removed when Clean is ran.