### PR TITLE
[buildtasks] Rework multitargeting support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <MSBuildPackageVersion>17.9.5</MSBuildPackageVersion>
-    <BindingExtPackageVersion>0.0.1-pre3</BindingExtPackageVersion>
+    <BindingExtPackageVersion>0.0.1-pre4</BindingExtPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <MSBuildPackageVersion>17.9.5</MSBuildPackageVersion>
-    <BindingExtPackageVersion>0.0.1-pre4</BindingExtPackageVersion>
+    <BindingExtPackageVersion>0.0.1-pre5</BindingExtPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <MSBuildPackageVersion>17.9.5</MSBuildPackageVersion>
-    <BindingExtPackageVersion>0.0.1-pre5</BindingExtPackageVersion>
+    <BindingExtPackageVersion>0.0.1-pre6</BindingExtPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <MSBuildPackageVersion>17.9.5</MSBuildPackageVersion>
-    <BindingExtPackageVersion>0.0.1-pre6</BindingExtPackageVersion>
+    <BindingExtPackageVersion>0.0.1-pre7</BindingExtPackageVersion>
   </PropertyGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -305,15 +305,15 @@ When packaging a native Android library (.aar) file, gradle/maven dependencies a
 The `facebook/android/native/mauifacebook/build.gradle.kts` file is configured to copy facebook dependencies into a `bin/outputs/deps` folder. Some of this content is then referenced by the .NET MAUI sample project:
 
 ```xml
-<AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-android-sdk-17.0.0.aar">
+<AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\deps\facebook-android-sdk-17.0.0.aar">
     <Bind>false</Bind>
     <Visible>false</Visible>
 </AndroidLibrary>
-<AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-common-17.0.0.aar">
+<AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\depsfacebook-common-17.0.0.aar">
     <Bind>false</Bind>
     <Visible>false</Visible>
 </AndroidLibrary>
-<AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-core-17.0.0.aar">
+<AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\deps\facebook-core-17.0.0.aar">
     <Bind>false</Bind>
     <Visible>false</Visible>
 </AndroidLibrary>

--- a/README.md
+++ b/README.md
@@ -309,7 +309,7 @@ The `facebook/android/native/mauifacebook/build.gradle.kts` file is configured t
     <Bind>false</Bind>
     <Visible>false</Visible>
 </AndroidLibrary>
-<AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\depsfacebook-common-17.0.0.aar">
+<AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\deps\facebook-common-17.0.0.aar">
     <Bind>false</Bind>
     <Visible>false</Visible>
 </AndroidLibrary>

--- a/facebook/sample/Sample.csproj
+++ b/facebook/sample/Sample.csproj
@@ -64,15 +64,15 @@
     <ItemGroup Condition="$(TargetFramework.Contains('android'))">
         <ProjectReference Include="..\android\Facebook.Android.Binding\Facebook.Android.Binding.csproj" />
         <!-- Include core facebook dependencies. Starting in .NET 9 these can potentially be replaced with @(AndroidMavenPackage) -->
-        <AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-android-sdk-17.0.0.aar">
+        <AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\deps\facebook-android-sdk-17.0.0.aar">
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>
-        <AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-common-17.0.0.aar">
+        <AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\depsfacebook-common-17.0.0.aar">
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>
-        <AndroidLibrary Include="..\android\native\mauifacebook\bin\outputs\deps\facebook-core-17.0.0.aar">
+        <AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\deps\facebook-core-17.0.0.aar">
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>

--- a/facebook/sample/Sample.csproj
+++ b/facebook/sample/Sample.csproj
@@ -68,7 +68,7 @@
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>
-        <AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\depsfacebook-common-17.0.0.aar">
+        <AndroidLibrary Include="..\android\native\mauifacebook\bin\Release\$(TargetFramework)\outputs\deps\facebook-common-17.0.0.aar">
             <Bind>false</Bind>
             <Visible>false</Visible>
         </AndroidLibrary>

--- a/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
+++ b/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
@@ -21,7 +21,7 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>0.0.1-pre3</Version>
+    <Version>0.0.1-pre4</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>net,maui,netmaui,toolkit,kit,communitytoolkit,netmauitoolkit,mauicommunitytoolkit,slimbinding,binding</PackageTags>
@@ -39,8 +39,6 @@
     <None Include="$(MSBuildThisFileDirectory)../../build/nuget.png" Pack="true" PackagePath="/" />
     <None Include="$(MSBuildThisFileDirectory)../../README.md" Pack="true" PackagePath="/" />
     <None Include="$(MSBuildThisFileDirectory)targets/CommunityToolkit.Maui.BindingExtensions.targets" Pack="true" PackagePath="build" />
-    <None Include="$(MSBuildThisFileDirectory)targets/CommunityToolkit.Maui.BindingExtensions.targets" Pack="true" PackagePath="buildMultiTargeting" />
-    <None Include="$(MSBuildThisFileDirectory)targets/CommunityToolkit.Maui.BindingExtensions.multitargeting.props" Pack="true" PackagePath="buildMultiTargeting/CommunityToolkit.Maui.BindingExtensions.props" />
     <None Include="$(MSBuildThisFileDirectory)targets/Common.props" Pack="true" PackagePath="tools" />
     <None Include="$(MSBuildThisFileDirectory)targets/Common.android.targets" Pack="true" PackagePath="tools" />
     <None Include="$(MSBuildThisFileDirectory)targets/Common.macios.targets" Pack="true" PackagePath="tools" />

--- a/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
+++ b/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
@@ -21,7 +21,7 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>0.0.1-pre6</Version>
+    <Version>0.0.1-pre7</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>net,maui,netmaui,toolkit,kit,communitytoolkit,netmauitoolkit,mauicommunitytoolkit,slimbinding,binding</PackageTags>

--- a/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
+++ b/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
@@ -21,7 +21,7 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>0.0.1-pre5</Version>
+    <Version>0.0.1-pre6</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>net,maui,netmaui,toolkit,kit,communitytoolkit,netmauitoolkit,mauicommunitytoolkit,slimbinding,binding</PackageTags>

--- a/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
+++ b/src/CommunityToolkit.Maui.BindingExtensions/CommunityToolkit.Maui.BindingExtensions.csproj
@@ -21,7 +21,7 @@
     <Product>$(AssemblyName) ($(TargetFramework))</Product>
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <AssemblyFileVersion>1.0.0.0</AssemblyFileVersion>
-    <Version>0.0.1-pre4</Version>
+    <Version>0.0.1-pre5</Version>
     <PackageVersion>$(Version)$(VersionSuffix)</PackageVersion>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
     <PackageTags>net,maui,netmaui,toolkit,kit,communitytoolkit,netmauitoolkit,mauicommunitytoolkit,slimbinding,binding</PackageTags>

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.android.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.android.targets
@@ -5,7 +5,7 @@
 
   <PropertyGroup>
     <GradleProjectConfiguration Condition=" '$(GradleProjectConfiguration)' == '' ">Release</GradleProjectConfiguration>
-    <GradleProjectBuildDirectory Condition=" '$(GradleProjectBuildDirectory)' == '' ">bin</GradleProjectBuildDirectory>
+    <GradleProjectBuildDirectory Condition=" '$(GradleProjectBuildDirectory)' == '' ">bin/$(GradleProjectConfiguration)/$(TargetFramework)</GradleProjectBuildDirectory>
   </PropertyGroup>
 
   <ItemDefinitionGroup>
@@ -15,15 +15,6 @@
       <Visible>false</Visible>
     </GradleProjectReference>
   </ItemDefinitionGroup>
-
-  <PropertyGroup>
-    <_BuildGradleProjectsBeforeTargets Condition=" '$(IsRunningOuterBuild)' == 'true' ">
-      DispatchToInnerBuilds;
-    </_BuildGradleProjectsBeforeTargets>
-    <_BuildGradleProjectsDependsOn Condition=" '$(IsRunningOuterBuild)' != 'true' ">
-      _ResolveMonoAndroidSdks;
-    </_BuildGradleProjectsDependsOn>
-  </PropertyGroup>
 
 
   <Target Name="_GetBuildGradleProjectsInputs">
@@ -39,8 +30,8 @@
   </Target>
 
   <Target Name="_BuildGradleProjects"
-      Condition=" '@(GradleProjectReference->Count())' != '0' and $(OnlyBuildOuterIfMultiTargeting) "
-      DependsOnTargets="_GetBuildGradleProjectsInputs;$(_BuildGradleProjectsDependsOn)"
+      Condition=" '@(GradleProjectReference->Count())' != '0' "
+      DependsOnTargets="_GetBuildGradleProjectsInputs;_ResolveMonoAndroidSdks"
       BeforeTargets="$(_BuildGradleProjectsBeforeTargets);$(CompileDependsOn)"
       Inputs="@(_GradleInputs)"
       Outputs="@(_GradleOutputs)" >

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -7,6 +7,7 @@
   <PropertyGroup>
     <XcodeProjectConfiguration Condition=" '$(XcodeProjectConfiguration)' == '' ">Release</XcodeProjectConfiguration>
     <XcodeProjectBuildDirectory Condition=" '$(XcodeProjectBuildDirectory)' == '' ">bin/$(XcodeProjectConfiguration)/$(TargetFramework)</XcodeProjectBuildDirectory>
+    <XcodeProjectCacheDirectory Condition=" '$(XcodeProjectCacheDirectory)' == '' ">obj/$(XcodeProjectConfiguration)/$(TargetFramework)</XcodeProjectCacheDirectory>
 
     <XcodeBuildiOS Condition=" '$(XcodeBuildiOS)' == '' and '$(TargetPlatformIdentifier)' == 'ios' ">true</XcodeBuildiOS>
     <XcodeBuildMacCatalyst Condition=" '$(XcodeBuildMacCatalyst)' == '' and '$(TargetPlatformIdentifier)' == 'maccatalyst' ">true</XcodeBuildMacCatalyst>
@@ -21,10 +22,11 @@
     <XcodeProjectReference>
       <Kind>Framework</Kind>
       <SmartLink>true</SmartLink>
-      <XCDerivedDataDir>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/DerivedData/%(Filename)-$(TargetPlatformIdentifier)</XCDerivedDataDir>
-      <XCArchiveiOS>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)$(TargetPlatformIdentifier)/ios.xcarchive</XCArchiveiOS>
-      <XCArchiveiOSSimulator>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/iossimulator.xcarchive</XCArchiveiOSSimulator>
-      <XCArchiveMacCatalyst>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/maccatalyst.xcarchive</XCArchiveMacCatalyst>
+      <XCArchiveiOS>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)iOS.xcarchive</XCArchiveiOS>
+      <XCArchiveiOSSimulator>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)iOSSimulator.xcarchive</XCArchiveiOSSimulator>
+      <XCArchiveMacCatalyst>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)MacCatalyst.xcarchive</XCArchiveMacCatalyst>
+      <XCDerivedDataDir>%(RootDir)%(Directory)$(XcodeProjectCacheDirectory)/DerivedData</XCDerivedDataDir>
+      <XCPackageCacheDir>%(RootDir)%(Directory)$(XcodeProjectCacheDirectory)/Cache</XCPackageCacheDir>
     </XcodeProjectReference>
   </ItemDefinitionGroup>
 
@@ -43,8 +45,11 @@
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.h" />
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.pbxproj" />
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.xcworkspace"/>
-      <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectBuildDirectory)/**/*')" />
-      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/_BuildXcodeProjects.stamp')" />
+      <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)bin/**/*" />
+      <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)obj/**/*" />
+      <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectBuildDirectory)/**/*" />
+      <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectCacheDirectory)/**/*" />
+      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)_BuildXcodeProjects.stamp')" />
     </ItemGroup>
   </Target>
 
@@ -53,14 +58,14 @@
       DependsOnTargets="_GetBuildXcodeProjectsInputs"
       Inputs="@(_XcbInputs)"
       Outputs="@(_XcbOutputs)" >
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)')" />
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)')" />
 
     <XcodeBuild
-        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOS)&quot; -destination &quot;generic/platform=iOS&quot; -derivedDataPath &quot;%(XcodeProjectReference.XCDerivedDataDir)&quot; $(_XcArchiveExtraArgs)"
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOS)&quot; -destination &quot;generic/platform=iOS&quot; $(_XcArchiveExtraArgs)"
         WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
     </XcodeBuild>
     <XcodeBuild
-        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOSSimulator)&quot; -destination &quot;generic/platform=iOS Simulator&quot; -derivedDataPath &quot;%(XcodeProjectReference.XCDerivedDataDir)&quot; $(_XcArchiveExtraArgs)"
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOSSimulator)&quot; -destination &quot;generic/platform=iOS Simulator&quot; $(_XcArchiveExtraArgs)"
         WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
     </XcodeBuild>
 
@@ -68,14 +73,14 @@
       <_CreateXcFxArgs Include="-create-xcframework" />
       <_CreateXcFxArgs Include="@(XcodeProjectReference->'-archive %(XCArchiveiOS) -framework %(SchemeName).framework')" />
       <_CreateXcFxArgs Include="@(XcodeProjectReference->'-archive %(XCArchiveiOSSimulator) -framework %(SchemeName).framework')" />
-      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/%(SchemeName)-$(TargetPlatformIdentifier).xcframework')" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(SchemeName)$(TargetPlatformIdentifier).xcframework')" />
     </ItemGroup>
     <XcodeBuild
         Arguments="@(_CreateXcFxArgs, ' ')"
         WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
     </XcodeBuild>
 
-    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
   </Target>
 
   <Target Name="_BuildXcodeProjectsForMacCatalyst"
@@ -83,24 +88,25 @@
       DependsOnTargets="_GetBuildXcodeProjectsInputs"
       Inputs="@(_XcbInputs)"
       Outputs="@(_XcbOutputs)" >
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)')" />
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)')" />
 
+    <!-- Override derivedDataPath and packageCachePath to avoid conflicts with building in parallel -->
     <XcodeBuild
-        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveMacCatalyst)&quot; -destination &quot;generic/platform=macOS,variant=Mac Catalyst&quot; -derivedDataPath &quot;%(XcodeProjectReference.XCDerivedDataDir)&quot; $(_XcArchiveExtraArgs)"
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveMacCatalyst)&quot; -destination &quot;generic/platform=macOS,variant=Mac Catalyst&quot; -derivedDataPath &quot;%(XcodeProjectReference.XCDerivedDataDir)&quot; -packageCachePath &quot;%(XcodeProjectReference.XCPackageCacheDir)&quot; $(_XcArchiveExtraArgs)"
         WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
     </XcodeBuild>
 
     <ItemGroup>
       <_CreateXcFxArgs Include="-create-xcframework" />
       <_CreateXcFxArgs Include="@(XcodeProjectReference->'-archive %(XCArchiveMacCatalyst) -framework %(SchemeName).framework')" />
-      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/%(SchemeName)-$(TargetPlatformIdentifier).xcframework')" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(SchemeName)$(TargetPlatformIdentifier).xcframework')" />
     </ItemGroup>
     <XcodeBuild
         Arguments="@(_CreateXcFxArgs, ' ')"
         WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
     </XcodeBuild>
 
-    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
   </Target>
 
   <Target Name="_BuildXcodeProjects"
@@ -108,7 +114,7 @@
       DependsOnTargets="$(BuildXcodeProjectsDependsOnTargets);_BuildXcodeProjectsForiOS;_BuildXcodeProjectsForMacCatalyst"
       BeforeTargets="$(_BuildXcodeProjectsBeforeTargets)" >
     <ItemGroup>
-      <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/%(SchemeName)-$(TargetPlatformIdentifier).xcframework')">
+      <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(SchemeName)$(TargetPlatformIdentifier).xcframework')">
         <Kind>%(XcodeProjectReference.Kind)</Kind>
         <SmartLink>%(XcodeProjectReference.SmartLink)</SmartLink>
       </NativeReference>
@@ -120,9 +126,9 @@
 
   <Target Name="_GetSharpieBindInputs">
     <ItemGroup>
-      <_SharpieInputs Include="%(XcodeProjectReference.XCArchiveiOS)/**/*.*" Condition=" '$(XcodeBuildiOS)' == 'true' " />
-      <_SharpieInputs Include="%(XcodeProjectReference.XCArchiveMacCatalyst)/**/*.*" Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "/>
-      <_SharpieOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/_SharpieBindXcodeProjects.stamp')" />
+      <_SharpieInputs Include="%(XcodeProjectReference.XCArchiveiOS)/**/*" Condition=" '$(XcodeBuildiOS)' == 'true' " />
+      <_SharpieInputs Include="%(XcodeProjectReference.XCArchiveMacCatalyst)/**/*" Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "/>
+      <_SharpieOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/%(Filename)/_SharpieBindXcodeProjects.stamp')" />
     </ItemGroup>
   </Target>
 
@@ -153,7 +159,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--output=&quot;%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie&quot; --namespace=%(SharpieNamespace) --sdk=$(SharpieSdkName)')" />
+      <_ObjSharpieArgs Include="@(XcodeProjectReference->'--output=&quot;%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/%(Filename)&quot; --namespace=%(SharpieNamespace) --sdk=$(SharpieSdkName)')" />
       <_ObjSharpieArgs Condition=" '$(XcodeBuildiOS)' == 'true' "
           Include="@(XcodeProjectReference->'--scope=&quot;%(XCArchiveiOS)/Products/Library/Frameworks/%(SchemeName).framework/Headers&quot; &quot;%(XCArchiveiOS)/Products/Library/Frameworks/%(SchemeName).framework/Headers/%(SchemeName)-Swift.h&quot;')" />
       <_ObjSharpieArgs Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "
@@ -162,7 +168,7 @@
 
     <Sharpie Arguments="bind @(_ObjSharpieArgs, ' ')" />
 
-    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/_SharpieBindXcodeProjects.stamp')" AlwaysCreate="true" />
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/%(Filename)/_SharpieBindXcodeProjects.stamp')" AlwaysCreate="true" />
   </Target>
 
 
@@ -176,9 +182,7 @@
 
   <Target Name="_CleanXcodeProjects"
       Condition=" '@(XcodeProjectReference->Count())' != '0' ">
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)')" />
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie')" />
-
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)')" />
   </Target>
 
 </Project>

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -112,8 +112,7 @@
 
   <Target Name="_BuildXcodeProjects"
       Condition=" '@(XcodeProjectReference->Count())' != '0' "
-      DependsOnTargets="$(BuildXcodeProjectsDependsOnTargets);_BuildXcodeProjectsForiOS;_BuildXcodeProjectsForMacCatalyst"
-      BeforeTargets="$(_BuildXcodeProjectsBeforeTargets)" >
+      DependsOnTargets="$(BuildXcodeProjectsDependsOnTargets);_BuildXcodeProjectsForiOS;_BuildXcodeProjectsForMacCatalyst" >
     <ItemGroup>
       <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(SchemeName)$(TargetPlatformIdentifier).xcframework')">
         <Kind>%(XcodeProjectReference.Kind)</Kind>
@@ -136,7 +135,6 @@
   <Target Name="_SharpieBindXcodeProjects"
       Condition=" '@(XcodeProjectReference->Count())' != '0' and '@(XcodeProjectReference->'%(SharpieBind)')' == 'true' "
       DependsOnTargets="_GetSharpieBindInputs;_BuildXcodeProjects"
-      BeforeTargets="$(_BuildXcodeProjectsBeforeTargets)"
       Inputs="@(_SharpieInputs)"
       Outputs="@(_SharpieOutputs)">
 

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -34,6 +34,7 @@
   <PropertyGroup>
     <CoreBuildDependsOn>
       _BuildXcodeProjects;
+      _SharpieBindXcodeProjects;
       $(CoreBuildDependsOn);
     </CoreBuildDependsOn>
   </PropertyGroup>

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.macios.targets
@@ -6,11 +6,10 @@
 
   <PropertyGroup>
     <XcodeProjectConfiguration Condition=" '$(XcodeProjectConfiguration)' == '' ">Release</XcodeProjectConfiguration>
-    <XcodeProjectBuildDirectory Condition=" '$(XcodeProjectBuildDirectory)' == '' ">bin</XcodeProjectBuildDirectory>
+    <XcodeProjectBuildDirectory Condition=" '$(XcodeProjectBuildDirectory)' == '' ">bin/$(XcodeProjectConfiguration)/$(TargetFramework)</XcodeProjectBuildDirectory>
 
-    <XcodeBuildiOS Condition=" '$(XcodeBuildiOS)' == '' and ($(TargetFrameworks.Contains('ios')) or $(TargetFramework.Contains('ios'))) ">true</XcodeBuildiOS>
-    <XcodeBuildiOSSimulator Condition=" '$(XcodeBuildiOSSimulator)' == '' and ($(TargetFrameworks.Contains('ios')) or $(TargetFramework.Contains('ios'))) ">true</XcodeBuildiOSSimulator>
-    <XcodeBuildMacCatalyst Condition=" '$(XcodeBuildMacCatalyst)' == '' and ($(TargetFrameworks.Contains('maccatalyst')) or $(TargetFramework.Contains('maccatalyst'))) ">true</XcodeBuildMacCatalyst>
+    <XcodeBuildiOS Condition=" '$(XcodeBuildiOS)' == '' and '$(TargetPlatformIdentifier)' == 'ios' ">true</XcodeBuildiOS>
+    <XcodeBuildMacCatalyst Condition=" '$(XcodeBuildMacCatalyst)' == '' and '$(TargetPlatformIdentifier)' == 'maccatalyst' ">true</XcodeBuildMacCatalyst>
 
     <EnableDefaultSharpieiOSItems Condition=" '$(EnableDefaultSharpieiOSItems)' == '' ">false</EnableDefaultSharpieiOSItems>
 
@@ -22,21 +21,20 @@
     <XcodeProjectReference>
       <Kind>Framework</Kind>
       <SmartLink>true</SmartLink>
-      <XCArchiveiOS>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/ios.xcarchive</XCArchiveiOS>
-      <XCArchiveiOSSimulator>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/iossimulator.xcarchive</XCArchiveiOSSimulator>
-      <XCArchiveMacCatalyst>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/maccatalyst.xcarchive</XCArchiveMacCatalyst>
+      <XCDerivedDataDir>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/DerivedData/%(Filename)-$(TargetPlatformIdentifier)</XCDerivedDataDir>
+      <XCArchiveiOS>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)$(TargetPlatformIdentifier)/ios.xcarchive</XCArchiveiOS>
+      <XCArchiveiOSSimulator>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/iossimulator.xcarchive</XCArchiveiOSSimulator>
+      <XCArchiveMacCatalyst>%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/maccatalyst.xcarchive</XCArchiveMacCatalyst>
     </XcodeProjectReference>
   </ItemDefinitionGroup>
 
-  <PropertyGroup>
-    <_BuildXcodeProjectsBeforeTargets>
-      BeforeBuild;
-    </_BuildXcodeProjectsBeforeTargets>
-    <_BuildXcodeProjectsBeforeTargets Condition=" '$(IsRunningOuterBuild)' == 'true' ">
-      DispatchToInnerBuilds;
-    </_BuildXcodeProjectsBeforeTargets>
-  </PropertyGroup>
 
+  <PropertyGroup>
+    <CoreBuildDependsOn>
+      _BuildXcodeProjects;
+      $(CoreBuildDependsOn);
+    </CoreBuildDependsOn>
+  </PropertyGroup>
 
   <Target Name="_GetBuildXcodeProjectsInputs">
     <ItemGroup>
@@ -46,77 +44,90 @@
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.pbxproj" />
       <_XcbInputs Include="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)**/*.xcworkspace"/>
       <_XcbInputs Remove="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)$(XcodeProjectBuildDirectory)/**/*')" />
-      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/_BuildXcodeProjects.stamp')" />
+      <_XcbOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/_BuildXcodeProjects.stamp')" />
     </ItemGroup>
   </Target>
 
-  <Target Name="_BuildXcodeProjects"
-      Condition=" '@(XcodeProjectReference->Count())' != '0' and $(OnlyBuildOuterIfMultiTargeting) "
-      DependsOnTargets="_GetBuildXcodeProjectsInputs;$(BuildXcodeProjectsDependsOnTargets)"
-      BeforeTargets="$(_BuildXcodeProjectsBeforeTargets)"
+  <Target Name="_BuildXcodeProjectsForiOS"
+      Condition=" '@(XcodeProjectReference->Count())' != '0' and '$(XcodeBuildiOS)' == 'true' "
+      DependsOnTargets="_GetBuildXcodeProjectsInputs"
       Inputs="@(_XcbInputs)"
       Outputs="@(_XcbOutputs)" >
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)')" />
 
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)')" />
-
-    <!-- Create xcarchive files for configured platforms -->
-    <XcodeBuild Condition=" '$(XcodeBuildiOS)' == 'true' "
-        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOS)&quot; -destination &quot;generic/platform=iOS&quot; $(_XcArchiveExtraArgs)"
+    <XcodeBuild
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOS)&quot; -destination &quot;generic/platform=iOS&quot; -derivedDataPath &quot;%(XcodeProjectReference.XCDerivedDataDir)&quot; $(_XcArchiveExtraArgs)"
+        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
+    </XcodeBuild>
+    <XcodeBuild
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOSSimulator)&quot; -destination &quot;generic/platform=iOS Simulator&quot; -derivedDataPath &quot;%(XcodeProjectReference.XCDerivedDataDir)&quot; $(_XcArchiveExtraArgs)"
         WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
     </XcodeBuild>
 
-    <XcodeBuild Condition=" '$(XcodeBuildiOSSimulator)' == 'true' "
-        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveiOSSimulator)&quot; -destination &quot;generic/platform=iOS Simulator&quot; $(_XcArchiveExtraArgs)"
-        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
-    </XcodeBuild>
-
-    <XcodeBuild Condition=" '$(XcodeBuildMacCatalyst)' == 'true' "
-        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveMacCatalyst)&quot; -destination &quot;generic/platform=macOS,variant=Mac Catalyst&quot; $(_XcArchiveExtraArgs)"
-        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
-    </XcodeBuild>
-
-    <!-- Create xcframework file from xcarchive files -->
     <ItemGroup>
       <_CreateXcFxArgs Include="-create-xcframework" />
-      <_CreateXcFxArgs Condition=" '$(XcodeBuildiOS)' == 'true' "
-          Include="@(XcodeProjectReference->'-archive %(XCArchiveiOS) -framework %(SchemeName).framework')" />
-      <_CreateXcFxArgs Condition=" '$(XcodeBuildiOSSimulator)' == 'true' "
-          Include="@(XcodeProjectReference->'-archive %(XCArchiveiOSSimulator) -framework %(SchemeName).framework')" />
-      <_CreateXcFxArgs Condition=" '$(XcodeBuildMacCatalyst)' == 'true' "
-          Include="@(XcodeProjectReference->'-archive %(XCArchiveMacCatalyst) -framework %(SchemeName).framework')" />
-      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/%(SchemeName).xcframework')" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-archive %(XCArchiveiOS) -framework %(SchemeName).framework')" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-archive %(XCArchiveiOSSimulator) -framework %(SchemeName).framework')" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/%(SchemeName)-$(TargetPlatformIdentifier).xcframework')" />
     </ItemGroup>
+    <XcodeBuild
+        Arguments="@(_CreateXcFxArgs, ' ')"
+        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
+    </XcodeBuild>
 
-    <XcodeBuild Arguments="@(_CreateXcFxArgs, ' ')"
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="_BuildXcodeProjectsForMacCatalyst"
+      Condition=" '@(XcodeProjectReference->Count())' != '0' and  '$(XcodeBuildMacCatalyst)' == 'true' "
+      DependsOnTargets="_GetBuildXcodeProjectsInputs"
+      Inputs="@(_XcbInputs)"
+      Outputs="@(_XcbOutputs)" >
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)')" />
+
+    <XcodeBuild
+        Arguments="-project &quot;%(XcodeProjectReference.FullPath)&quot; archive -scheme %(SchemeName) -configuration $(XcodeProjectConfiguration) -archivePath &quot;%(XcodeProjectReference.XCArchiveMacCatalyst)&quot; -destination &quot;generic/platform=macOS,variant=Mac Catalyst&quot; -derivedDataPath &quot;%(XcodeProjectReference.XCDerivedDataDir)&quot; $(_XcArchiveExtraArgs)"
         WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
     </XcodeBuild>
 
     <ItemGroup>
-      <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/%(SchemeName).xcframework')">
+      <_CreateXcFxArgs Include="-create-xcframework" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-archive %(XCArchiveMacCatalyst) -framework %(SchemeName).framework')" />
+      <_CreateXcFxArgs Include="@(XcodeProjectReference->'-output %(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/%(SchemeName)-$(TargetPlatformIdentifier).xcframework')" />
+    </ItemGroup>
+    <XcodeBuild
+        Arguments="@(_CreateXcFxArgs, ' ')"
+        WorkingDirectory="%(XcodeProjectReference.RootDir)%(XcodeProjectReference.Directory)" >
+    </XcodeBuild>
+
+    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
+  </Target>
+
+  <Target Name="_BuildXcodeProjects"
+      Condition=" '@(XcodeProjectReference->Count())' != '0' "
+      DependsOnTargets="$(BuildXcodeProjectsDependsOnTargets);_BuildXcodeProjectsForiOS;_BuildXcodeProjectsForMacCatalyst"
+      BeforeTargets="$(_BuildXcodeProjectsBeforeTargets)" >
+    <ItemGroup>
+      <NativeReference Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)/%(SchemeName)-$(TargetPlatformIdentifier).xcframework')">
         <Kind>%(XcodeProjectReference.Kind)</Kind>
         <SmartLink>%(XcodeProjectReference.SmartLink)</SmartLink>
       </NativeReference>
     </ItemGroup>
-
     <Error Condition=" !Exists('@(NativeReference)') " Text="Xcode project built successfully but did not produce expected output file: '@(NativeReference)'" />
     <Message Text="Adding reference to Xcode project output: @(NativeReference)" />
-
-    <Touch Files="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)/_BuildXcodeProjects.stamp')" AlwaysCreate="true" />
   </Target>
 
 
   <Target Name="_GetSharpieBindInputs">
     <ItemGroup>
-      <_SharpieInputs Condition=" '$(XcodeBuildiOS)' == 'true' "
-          Include="%(XcodeProjectReference.XCArchiveiOS)/**/*.*" />
-      <_SharpieInputs Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "
-          Include="%(XcodeProjectReference.XCArchiveMacCatalyst)/**/*.*" />
+      <_SharpieInputs Include="%(XcodeProjectReference.XCArchiveiOS)/**/*.*" Condition=" '$(XcodeBuildiOS)' == 'true' " />
+      <_SharpieInputs Include="%(XcodeProjectReference.XCArchiveMacCatalyst)/**/*.*" Condition=" '$(XcodeBuildiOS)' != 'true' and '$(XcodeBuildMacCatalyst)' == 'true' "/>
       <_SharpieOutputs Include="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie/_SharpieBindXcodeProjects.stamp')" />
     </ItemGroup>
   </Target>
 
   <Target Name="_SharpieBindXcodeProjects"
-      Condition=" '@(XcodeProjectReference->Count())' != '0' and '@(XcodeProjectReference->'%(SharpieBind)')' == 'true' and $(OnlyBuildOuterIfMultiTargeting) "
+      Condition=" '@(XcodeProjectReference->Count())' != '0' and '@(XcodeProjectReference->'%(SharpieBind)')' == 'true' "
       DependsOnTargets="_GetSharpieBindInputs;_BuildXcodeProjects"
       BeforeTargets="$(_BuildXcodeProjectsBeforeTargets)"
       Inputs="@(_SharpieInputs)"
@@ -165,7 +176,9 @@
 
   <Target Name="_CleanXcodeProjects"
       Condition=" '@(XcodeProjectReference->Count())' != '0' ">
-    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)')" />
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/%(Filename)-$(TargetPlatformIdentifier)')" />
+    <RemoveDir Directories="@(XcodeProjectReference->'%(RootDir)%(Directory)$(XcodeProjectBuildDirectory)/sharpie')" />
+
   </Target>
 
 </Project>

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.props
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/Common.props
@@ -2,9 +2,6 @@
 <Project>
 
   <PropertyGroup>
-    <IsRunningOuterBuild Condition=" '$(IsRunningOuterBuild)' == '' ">false</IsRunningOuterBuild>
-    <OnlyBuildOuterIfMultiTargeting>false</OnlyBuildOuterIfMultiTargeting>
-    <OnlyBuildOuterIfMultiTargeting Condition=" '$(TargetFrameworks)' == '' or $(IsRunningOuterBuild) ">true</OnlyBuildOuterIfMultiTargeting>
     <BindingExtBuildTasksAssembly Condition= " !Exists('$(BindingExtBuildTasksAssembly)') ">CommunityToolkit.Maui.BindingExtensions.dll</BindingExtBuildTasksAssembly>
     <HOME Condition=" '$(HOME)' == '' ">$(USERPROFILE)</HOME>
   </PropertyGroup>

--- a/src/CommunityToolkit.Maui.BindingExtensions/targets/CommunityToolkit.Maui.BindingExtensions.multitargeting.props
+++ b/src/CommunityToolkit.Maui.BindingExtensions/targets/CommunityToolkit.Maui.BindingExtensions.multitargeting.props
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Project>
-
-  <PropertyGroup>
-    <IsRunningOuterBuild>true</IsRunningOuterBuild>
-  </PropertyGroup>
-
-</Project>


### PR DESCRIPTION
Reworks multitargeting support to ensure native build targets always run
for every target framework in the project, rather than trying to run
once at the top of a multitargeted build.

Build output directories have been updated to include $(TargetFramework)
to avoid potential conflicts with using the same output directory for
a multitargeting project.